### PR TITLE
Fix vue prop syncing and add trailing comma to the accessors of angular

### DIFF
--- a/packages/angular-output-target/src/generate-value-accessors.ts
+++ b/packages/angular-output-target/src/generate-value-accessors.ts
@@ -83,7 +83,7 @@ function createValueAccessor(srcFileContents: string, valueAccessor: ValueAccess
 
   return srcFileContents
     .replace(VALUE_ACCESSOR_SELECTORS, valueAccessor.elementSelectors.join(', '))
-    .replace(VALUE_ACCESSOR_EVENTTARGETS, hostContents.join('\n'));
+    .replace(VALUE_ACCESSOR_EVENTTARGETS, hostContents.join(',\n'));
 }
 
 function copyResources(config: Config, resourcesFilesToCopy: string[], directory: string) {

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -16,12 +16,21 @@ export const createCommonRender = (tagName: string, eventNames: string[] = []) =
       };
     }, vueElement.$listeners);
 
+    const attributes = vueElement.$props
+      ? Object.keys(vueElement.$props).reduce((attrs: any, prop: string) => {
+          const attributeName = toDashCase(prop);
+          attrs[attributeName] = vueElement.$props[prop];
+          return attrs;
+        }, {})
+      : {};
+
     return createElement(
       tagName,
       {
         ref: 'wc',
         domProps: vueElement.$props,
         on: allListeners,
+        attrs: { ...attributes },
       },
       [vueElement.$slots.default],
     );
@@ -31,3 +40,13 @@ export const createCommonMethod = (methodName: string) =>
   function (...args: any[]) {
     this.$refs.wc[methodName](...args);
   } as unknown;
+
+export const toLowerCase = (str: string) => str.toLowerCase();
+
+export const toDashCase = (str: string) =>
+  toLowerCase(
+    str
+      .replace(/([A-Z0-9])/g, (g) => ' ' + g[0])
+      .trim()
+      .replace(/ /g, '-'),
+  );

--- a/packages/vue-output-target/vue-component-lib/utils.ts
+++ b/packages/vue-output-target/vue-component-lib/utils.ts
@@ -28,7 +28,7 @@ export const createCommonRender = (tagName: string, eventNames: string[] = []) =
       tagName,
       {
         ref: 'wc',
-        domProps: vueElement.$props,
+        domProps: { ...vueElement.$props },
         on: allListeners,
         attrs: { ...attributes },
       },


### PR DESCRIPTION
Hi

First we need to fix this issue #128 .

Vue
With vue we had the issue that the props did update after the first render.

Angular
In the generated accessor files the host list needed a comma as a separator.

