### PR TITLE
#54 added outputs to generated angular components

### DIFF
--- a/example-project/component-library-angular/src/directives/proxies.ts
+++ b/example-project/component-library-angular/src/directives/proxies.ts
@@ -16,6 +16,7 @@ import { Components } from 'component-library';
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'shape', 'size', 'strong', 'target', 'type'],
+  outputs: ['myFocus', 'myBlur'],
 })
 export class MyButton {
   protected el: HTMLMyButtonElement;
@@ -48,6 +49,7 @@ export declare interface MyButton extends Components.MyButton {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['alignment', 'checked', 'color', 'disabled', 'indeterminate', 'justify', 'labelPlacement', 'mode', 'name', 'value'],
+  outputs: ['ionChange', 'ionFocus', 'ionBlur'],
 })
 export class MyCheckbox {
   protected el: HTMLMyCheckboxElement;
@@ -88,6 +90,7 @@ This event will not emit when programmatically setting the `checked` property.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['age', 'favoriteKidName', 'first', 'kidsNames', 'last', 'middle'],
+  outputs: ['myCustomEvent', 'myCustomNestedEvent'],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -123,6 +126,7 @@ export declare interface MyComponent extends Components.MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'],
+  outputs: ['myInput', 'myChange', 'myBlur', 'myFocus'],
 })
 export class MyInput {
   protected el: HTMLMyInputElement;
@@ -164,6 +168,7 @@ export declare interface MyInput extends Components.MyInput {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: [],
 })
 export class MyList {
   protected el: HTMLMyListElement;
@@ -185,6 +190,7 @@ export declare interface MyList extends Components.MyList {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: [],
 })
 export class MyListItem {
   protected el: HTMLMyListItemElement;
@@ -208,6 +214,7 @@ export declare interface MyListItem extends Components.MyListItem {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
+  outputs: ['myPopoverDidPresent', 'myPopoverWillPresent', 'myPopoverWillDismiss', 'myPopoverDidDismiss'],
 })
 export class MyPopover {
   protected el: HTMLMyPopoverElement;
@@ -250,6 +257,7 @@ export declare interface MyPopover extends Components.MyPopover {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['alignment', 'color', 'disabled', 'justify', 'labelPlacement', 'mode', 'name', 'value'],
+  outputs: ['ionFocus', 'ionBlur'],
 })
 export class MyRadio {
   protected el: HTMLMyRadioElement;
@@ -282,6 +290,7 @@ export declare interface MyRadio extends Components.MyRadio {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['allowEmptySelection', 'compareWith', 'name', 'value'],
+  outputs: ['myChange'],
 })
 export class MyRadioGroup {
   protected el: HTMLMyRadioGroupElement;
@@ -314,6 +323,7 @@ This event will not emit when programmatically setting the `value` property.
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'snaps', 'step', 'ticks', 'value'],
+  outputs: ['myChange', 'myFocus', 'myBlur'],
 })
 export class MyRange {
   protected el: HTMLMyRangeElement;
@@ -351,6 +361,7 @@ export declare interface MyRange extends Components.MyRange {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: [],
 })
 export class MyToggle {
   protected el: HTMLMyToggleElement;
@@ -373,6 +384,7 @@ export declare interface MyToggle extends Components.MyToggle {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['visible'],
+  outputs: [],
 })
 export class MyToggleContent {
   protected el: HTMLMyToggleContentElement;

--- a/packages/angular/src/generate-angular-component.ts
+++ b/packages/angular/src/generate-angular-component.ts
@@ -110,7 +110,9 @@ export const createAngularComponentDefinition = (
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [${formattedInputs}],${standaloneOption}
+  inputs: [${formattedInputs}],
+  outputs: [${formattedOutputs}]
+  ${standaloneOption}
 })
 export class ${tagNameAsPascal} {
   ${propertiesDeclarationText}

--- a/packages/angular/src/generate-angular-component.ts
+++ b/packages/angular/src/generate-angular-component.ts
@@ -111,8 +111,7 @@ export const createAngularComponentDefinition = (
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [${formattedInputs}],
-  outputs: [${formattedOutputs}]
-  ${standaloneOption}
+  outputs: [${formattedOutputs}],${standaloneOption}
 })
 export class ${tagNameAsPascal} {
   ${propertiesDeclarationText}

--- a/packages/angular/tests/generate-angular-component.test.ts
+++ b/packages/angular/tests/generate-angular-component.test.ts
@@ -15,6 +15,7 @@ describe('createAngularComponentDefinition()', () => {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: [],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -36,6 +37,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['my-input', 'my-other-input'],
+  outputs: [],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -63,6 +65,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: ['my-output', 'my-other-output'],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -86,6 +89,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: [],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -110,6 +114,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: [],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -133,6 +138,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['my-input', 'my-other-input'],
+  outputs: [],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -160,6 +166,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: ['my-output', 'my-other-output'],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -184,6 +191,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: [],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -206,6 +214,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  outputs: [],
   standalone: true
 })
 export class MyComponent {
@@ -239,6 +248,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['myMember'],
+  outputs: [],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The outputs property is missing causing webstorm to not recognize proxied outputs

This was fixed, but is missing in the latest version. This must've been forgotten when refactoring, right?

This is what gets generated when adding a @Event()

![grafik](https://github.com/user-attachments/assets/a5bbd084-c76f-4b5d-baf3-a3188e803d04)

Causing the outputs missing in the built component
![grafik](https://github.com/user-attachments/assets/0eb3c60c-8f05-4c7c-95bc-1bc0bc55c766)


Issue URL: https://github.com/stenciljs/output-targets/issues/54


## What is the new behavior?

- automatically add the output property to the angular `@Component` annotation

![grafik](https://github.com/user-attachments/assets/9cadb276-72b0-46a0-b62b-a7da70732aa5)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Also discussed here:
https://discord.com/channels/1347590794130755665/1348708014722383992/1354405579380101120