### PR TITLE
fix(react): forward ref to underlying web component

### DIFF
--- a/packages/react/src/runtime/create-component.ts
+++ b/packages/react/src/runtime/create-component.ts
@@ -7,7 +7,8 @@ type EventNames = Record<string, EventName | string>;
 // Type that's compatible with both React 18 and 19
 type StencilProps<I extends HTMLElement, E extends EventNames> = Omit<React.HTMLAttributes<I>, keyof E> &
   Partial<{ [K in keyof E]: E[K] extends EventName<infer T> ? (event: T) => void : (event: any) => void }> &
-  Partial<Omit<I, keyof HTMLElement>>;
+  Partial<Omit<I, keyof HTMLElement>> &
+  React.RefAttributes<I>;
 
 export type StencilReactComponent<I extends HTMLElement, E extends EventNames = {}> = React.FunctionComponent<
   StencilProps<I, E>


### PR DESCRIPTION
Bug Introduction
This issue was introduced in React output target version 1.0.5, following [this commit](https://github.com/stenciljs/output-targets/commit/f887ae76b0e9de58e46231af3376daf06f945071#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

Problem
Consumers were unable to use ref on web components wrapped by the React output target. This broke support for useRef and callback refs, preventing access to the underlying DOM element or its methods.

Resolution
The fix involves extending StencilProps with React.RefAttributes, enabling proper ref forwarding. This restores compatibility with useRef and callback refs, allowing direct DOM access and method invocation on the wrapped web components.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
