### PR TITLE
Feature/required inputs

### DIFF
--- a/example-project/component-library-angular/projects/library/src/directives/proxies.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/proxies.ts
@@ -440,7 +440,7 @@ export declare interface MyListScoped extends Components.MyListScoped {}
 
 @ProxyCmp({
   defineCustomElementFn: defineMyPopover,
-  inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
+  inputs: ['animated', 'backdropDismiss', { name: 'component', required: true }, 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
   methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss']
 })
 @Component({
@@ -448,7 +448,7 @@ export declare interface MyListScoped extends Components.MyListScoped {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
+  inputs: ['animated', 'backdropDismiss', { name: 'component', required: true }, 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
 })
 export class MyPopover {
   protected el: HTMLMyPopoverElement;

--- a/example-project/component-library-angular/projects/library/src/directives/proxies.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/proxies.ts
@@ -440,7 +440,7 @@ export declare interface MyListScoped extends Components.MyListScoped {}
 
 @ProxyCmp({
   defineCustomElementFn: defineMyPopover,
-  inputs: ['animated', 'backdropDismiss', { name: 'component', required: true }, 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
+  inputs: ['animated', 'backdropDismiss', 'component', 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
   methods: ['present', 'dismiss', 'onDidDismiss', 'onWillDismiss']
 })
 @Component({

--- a/packages/angular/src/generate-angular-component.ts
+++ b/packages/angular/src/generate-angular-component.ts
@@ -40,16 +40,16 @@ function createPropertyDeclaration(
  * @param inputs The inputs of the Stencil component (e.g. [{name: 'myInput', required: true]).
  * @returns The inputs list declaration as a string.
  */
-function formatInputs(
-  inputs: readonly ComponentInputProperty[],
-): string {
-  return inputs.map((item) => {
-    if (item.required) {
-      return `{ name: '${item}', required: true }`;
-    } else {
-      return `'${item}'`;
-    }
-  }).join(', ');
+function formatInputs(inputs: readonly ComponentInputProperty[]): string {
+  return inputs
+    .map((item) => {
+      if (item.required) {
+        return `{ name: '${item.name}', required: true }`;
+      } else {
+        return `'${item.name}'`;
+      }
+    })
+    .join(', ');
 }
 
 /**
@@ -78,7 +78,7 @@ export const createAngularComponentDefinition = (
   const hasInputs = inputs.length > 0;
   const hasOutputs = outputs.length > 0;
   const hasMethods = methods.length > 0;
-  
+
   // Formats the input strings into comma separated, single quoted values if optional.
   // Formats the required input strings into comma separated {name, required} objects.
   const formattedInputs = formatInputs(inputs);

--- a/packages/angular/src/generate-angular-component.ts
+++ b/packages/angular/src/generate-angular-component.ts
@@ -34,10 +34,32 @@ function createPropertyDeclaration(
 }
 
 /**
+ * Creates a formatted inputs text with required declaration.
+ *
+ * @param prop A ComponentCompilerEvent or ComponentCompilerProperty to turn into a property declaration.
+ * @param inputs The inputs of the Stencil component (e.g. ['myInput']).
+ * @param requiredInputs The inputs subset of the Stencil component that are required by component (e.g. ['myInput']).
+ * @returns The inputs list declaration as a string.
+ */
+function formatInputs(
+  inputs: string[],
+  requiredInputs: string[]
+): string {
+  return inputs.map((item) => {
+    if (requiredInputs.includes(item) {
+      return `{ name: '${item}', required: true }`;
+    } else {
+      return `'${item}'`;
+    }
+  }).join(', ');
+}
+
+/**
  * Creates an Angular component declaration from formatted Stencil compiler metadata.
  *
  * @param tagName The tag name of the component.
  * @param inputs The inputs of the Stencil component (e.g. ['myInput']).
+ * @param requiredInputs The inputs subset of the Stencil component that are required by component (e.g. ['myInput']).
  * @param outputs The outputs/events of the Stencil component. (e.g. ['myOutput']).
  * @param methods The methods of the Stencil component. (e.g. ['myMethod']).
  * @param includeImportCustomElements Whether to define the component as a custom element.
@@ -48,6 +70,7 @@ function createPropertyDeclaration(
 export const createAngularComponentDefinition = (
   tagName: string,
   inputs: readonly string[],
+  requiredInputs: readonly string[],
   outputs: readonly string[],
   methods: readonly string[],
   includeImportCustomElements = false,
@@ -60,8 +83,11 @@ export const createAngularComponentDefinition = (
   const hasOutputs = outputs.length > 0;
   const hasMethods = methods.length > 0;
 
-  // Formats the input strings into comma separated, single quoted values.
-  const formattedInputs = formatToQuotedList(inputs);
+  const optionalInputs = inputs.filter(
+  
+  // Formats the input strings into comma separated, single quoted values if optional.
+  // Formats the required input strings into comma separated {name, required} objects.
+  const formattedInputs = formatInputs(inputs, requiredInputs);
   // Formats the output strings into comma separated, single quoted values.
   const formattedOutputs = formatToQuotedList(outputs);
   // Formats the method strings into comma separated, single quoted values.

--- a/packages/angular/src/generate-angular-component.ts
+++ b/packages/angular/src/generate-angular-component.ts
@@ -1,6 +1,6 @@
 import type { CompilerJsDoc, ComponentCompilerEvent, ComponentCompilerProperty } from '@stencil/core/internal';
 
-import { createComponentEventTypeImports, dashToPascalCase, formatToQuotedList } from './utils';
+import { createComponentEventTypeImports, dashToPascalCase, formatToQuotedList, mapPropName } from './utils';
 import type { ComponentInputProperty, OutputType } from './types';
 
 /**
@@ -79,6 +79,8 @@ export const createAngularComponentDefinition = (
   const hasOutputs = outputs.length > 0;
   const hasMethods = methods.length > 0;
 
+  // Formats the input strings into comma separated, single quoted values.
+  const proxyCmpFormattedInputs = formatToQuotedList(inputs.map(mapPropName));
   // Formats the input strings into comma separated, single quoted values if optional.
   // Formats the required input strings into comma separated {name, required} objects.
   const formattedInputs = formatInputs(inputs);
@@ -96,7 +98,7 @@ export const createAngularComponentDefinition = (
   }
 
   if (hasInputs) {
-    proxyCmpOptions.push(`\n  inputs: [${formattedInputs}]`);
+    proxyCmpOptions.push(`\n  inputs: [${proxyCmpFormattedInputs}]`);
   }
 
   if (hasMethods) {

--- a/packages/angular/src/generate-angular-component.ts
+++ b/packages/angular/src/generate-angular-component.ts
@@ -42,11 +42,11 @@ function createPropertyDeclaration(
  * @returns The inputs list declaration as a string.
  */
 function formatInputs(
-  inputs: string[],
-  requiredInputs: string[]
+  inputs: readonly string[],
+  requiredInputs: readonly string[]
 ): string {
   return inputs.map((item) => {
-    if (requiredInputs.includes(item) {
+    if (requiredInputs.includes(item)) {
       return `{ name: '${item}', required: true }`;
     } else {
       return `'${item}'`;
@@ -82,8 +82,6 @@ export const createAngularComponentDefinition = (
   const hasInputs = inputs.length > 0;
   const hasOutputs = outputs.length > 0;
   const hasMethods = methods.length > 0;
-
-  const optionalInputs = inputs.filter(
   
   // Formats the input strings into comma separated, single quoted values if optional.
   // Formats the required input strings into comma separated {name, required} objects.

--- a/packages/angular/src/generate-angular-component.ts
+++ b/packages/angular/src/generate-angular-component.ts
@@ -1,7 +1,7 @@
 import type { CompilerJsDoc, ComponentCompilerEvent, ComponentCompilerProperty } from '@stencil/core/internal';
 
 import { createComponentEventTypeImports, dashToPascalCase, formatToQuotedList } from './utils';
-import type { OutputType } from './types';
+import type { ComponentInputProperty, OutputType } from './types';
 
 /**
  * Creates a property declaration.
@@ -37,16 +37,14 @@ function createPropertyDeclaration(
  * Creates a formatted inputs text with required declaration.
  *
  * @param prop A ComponentCompilerEvent or ComponentCompilerProperty to turn into a property declaration.
- * @param inputs The inputs of the Stencil component (e.g. ['myInput']).
- * @param requiredInputs The inputs subset of the Stencil component that are required by component (e.g. ['myInput']).
+ * @param inputs The inputs of the Stencil component (e.g. [{name: 'myInput', required: true]).
  * @returns The inputs list declaration as a string.
  */
 function formatInputs(
-  inputs: readonly string[],
-  requiredInputs: readonly string[]
+  inputs: readonly ComponentInputProperty[],
 ): string {
   return inputs.map((item) => {
-    if (requiredInputs.includes(item)) {
+    if (item.required) {
       return `{ name: '${item}', required: true }`;
     } else {
       return `'${item}'`;
@@ -58,8 +56,7 @@ function formatInputs(
  * Creates an Angular component declaration from formatted Stencil compiler metadata.
  *
  * @param tagName The tag name of the component.
- * @param inputs The inputs of the Stencil component (e.g. ['myInput']).
- * @param requiredInputs The inputs subset of the Stencil component that are required by component (e.g. ['myInput']).
+ * @param inputs The inputs of the Stencil component (e.g. [{name: 'myInput', required: true]).
  * @param outputs The outputs/events of the Stencil component. (e.g. ['myOutput']).
  * @param methods The methods of the Stencil component. (e.g. ['myMethod']).
  * @param includeImportCustomElements Whether to define the component as a custom element.
@@ -69,8 +66,7 @@ function formatInputs(
  */
 export const createAngularComponentDefinition = (
   tagName: string,
-  inputs: readonly string[],
-  requiredInputs: readonly string[],
+  inputs: readonly ComponentInputProperty[],
   outputs: readonly string[],
   methods: readonly string[],
   includeImportCustomElements = false,
@@ -85,7 +81,7 @@ export const createAngularComponentDefinition = (
   
   // Formats the input strings into comma separated, single quoted values if optional.
   // Formats the required input strings into comma separated {name, required} objects.
-  const formattedInputs = formatInputs(inputs, requiredInputs);
+  const formattedInputs = formatInputs(inputs);
   // Formats the output strings into comma separated, single quoted values.
   const formattedOutputs = formatToQuotedList(outputs);
   // Formats the method strings into comma separated, single quoted values.

--- a/packages/angular/src/output-angular.ts
+++ b/packages/angular/src/output-angular.ts
@@ -144,8 +144,10 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
   const proxyFileOutput = [];
 
   const filterInternalProps = (prop: { name: string; internal: boolean }) => !prop.internal;
-  const filterRequiredProps = (prop: { name: string; required: boolean }) => prop.required;
   const mapPropName = (prop: { name: string }) => prop.name;
+
+  // Ensure that virtual properties has required as false.
+  const mapInputProp = (prop: { name: string, required?: boolean }) => ({ name: prop.name, required: prop.required ?? false });
 
   const { componentCorePackage, customElementsDir } = outputTarget;
 
@@ -158,11 +160,10 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
       internalProps.push(...cmpMeta.properties.filter(filterInternalProps));
     }
 
-    const requiredInputs = internalProps.filter(filterRequiredProps).map(mapPropName);
-    const inputs = internalProps.map(mapPropName);
+    const inputs = internalProps.map(mapInputProp);
 
     if (cmpMeta.virtualProperties) {
-      inputs.push(...cmpMeta.virtualProperties.map(mapPropName));
+      inputs.push(...cmpMeta.virtualProperties.map(mapInputProp));
     }
 
     inputs.sort();
@@ -190,7 +191,6 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
     const componentDefinition = createAngularComponentDefinition(
       cmpMeta.tagName,
       inputs,
-      requiredInputs,
       outputs,
       methods,
       isCustomElementsBuild,

--- a/packages/angular/src/output-angular.ts
+++ b/packages/angular/src/output-angular.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import type { CompilerCtx, ComponentCompilerMeta, ComponentCompilerProperty, Config } from '@stencil/core/internal';
-import type { OutputTargetAngular, PackageJSON } from './types';
+import type { ComponentInputProperty, OutputTargetAngular, PackageJSON } from './types';
 import {
   relativeImport,
   normalizePath,
@@ -147,7 +147,10 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
   const mapPropName = (prop: { name: string }) => prop.name;
 
   // Ensure that virtual properties has required as false.
-  const mapInputProp = (prop: { name: string, required?: boolean }) => ({ name: prop.name, required: prop.required ?? false });
+  const mapInputProp = (prop: { name: string; required?: boolean }) => ({
+    name: prop.name,
+    required: prop.required ?? false,
+  });
 
   const { componentCorePackage, customElementsDir } = outputTarget;
 
@@ -166,7 +169,7 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
       inputs.push(...cmpMeta.virtualProperties.map(mapInputProp));
     }
 
-    inputs.sort();
+    const orderedInputs = sortBy(inputs, (cip: ComponentInputProperty) => cip.name);
 
     const outputs: string[] = [];
 
@@ -190,7 +193,7 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
      */
     const componentDefinition = createAngularComponentDefinition(
       cmpMeta.tagName,
-      inputs,
+      orderedInputs,
       outputs,
       methods,
       isCustomElementsBuild,

--- a/packages/angular/src/output-angular.ts
+++ b/packages/angular/src/output-angular.ts
@@ -144,6 +144,7 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
   const proxyFileOutput = [];
 
   const filterInternalProps = (prop: { name: string; internal: boolean }) => !prop.internal;
+  const filterRequiredProps = (prop: { name: string; required: boolean }) => prop.required;
   const mapPropName = (prop: { name: string }) => prop.name;
 
   const { componentCorePackage, customElementsDir } = outputTarget;
@@ -157,6 +158,7 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
       internalProps.push(...cmpMeta.properties.filter(filterInternalProps));
     }
 
+    const requiredInputs = internalProps.filter(filterRequiredProps).map(mapPropName);
     const inputs = internalProps.map(mapPropName);
 
     if (cmpMeta.virtualProperties) {
@@ -188,6 +190,7 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
     const componentDefinition = createAngularComponentDefinition(
       cmpMeta.tagName,
       inputs,
+      requiredInputs,
       outputs,
       methods,
       isCustomElementsBuild,

--- a/packages/angular/src/output-angular.ts
+++ b/packages/angular/src/output-angular.ts
@@ -10,6 +10,7 @@ import {
   createImportStatement,
   isOutputTypeCustomElementsBuild,
   OutputTypes,
+  mapPropName,
 } from './utils';
 import { createAngularComponentDefinition, createComponentTypeDefinition } from './generate-angular-component';
 import { generateAngularDirectivesFile } from './generate-angular-directives-file';
@@ -144,7 +145,6 @@ ${createImportStatement(componentLibImports, './angular-component-lib/utils')}\n
   const proxyFileOutput = [];
 
   const filterInternalProps = (prop: { name: string; internal: boolean }) => !prop.internal;
-  const mapPropName = (prop: { name: string }) => prop.name;
 
   // Ensure that virtual properties has required as false.
   const mapInputProp = (prop: { name: string; required?: boolean }) => ({

--- a/packages/angular/src/types.ts
+++ b/packages/angular/src/types.ts
@@ -53,4 +53,3 @@ export interface ComponentInputProperty {
   name: string;
   required: boolean;
 }
-

--- a/packages/angular/src/types.ts
+++ b/packages/angular/src/types.ts
@@ -48,3 +48,9 @@ export interface ValueAccessorConfig {
 export interface PackageJSON {
   types: string;
 }
+
+export interface ComponentInputProperty {
+  name: string;
+  required: boolean;
+}
+

--- a/packages/angular/src/utils.ts
+++ b/packages/angular/src/utils.ts
@@ -10,6 +10,8 @@ export const OutputTypes: { [key: string]: OutputType } = {
 
 export const toLowerCase = (str: string) => str.toLowerCase();
 
+export const mapPropName = (prop: { name: string }) => prop.name;
+
 export const dashToPascalCase = (str: string) =>
   toLowerCase(str)
     .split('-')

--- a/packages/angular/tests/generate-angular-component.test.ts
+++ b/packages/angular/tests/generate-angular-component.test.ts
@@ -27,7 +27,7 @@ export class MyComponent {
     });
 
     it('generates a component with inputs', () => {
-      const component = createAngularComponentDefinition('my-component', ['my-input', 'my-other-input'], [], [], false);
+      const component = createAngularComponentDefinition('my-component', [{name: 'my-input', required: false}, {name: 'my-other-input', required: false}], [], [], false);
       expect(component).toMatch(`@ProxyCmp({
   inputs: ['my-input', 'my-other-input']
 })
@@ -37,6 +37,28 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['my-input', 'my-other-input'],
+  standalone: false
+})
+export class MyComponent {
+  protected el: HTMLMyComponentElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}`);
+    });
+
+    it('generates a component with inputs (required)', () => {
+      const component = createAngularComponentDefinition('my-component', [{name: 'my-input', required: false}, {name: 'my-other-input', required: true}], [], [], false);
+      expect(component).toMatch(`@ProxyCmp({
+  inputs: ['my-input', 'my-other-input']
+})
+@Component({
+  selector: 'my-component',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['my-input', { name: 'my-other-input', required: true }],
   standalone: false
 })
 export class MyComponent {
@@ -126,7 +148,7 @@ export class MyComponent {
     });
 
     it('generates a component with inputs', () => {
-      const component = createAngularComponentDefinition('my-component', ['my-input', 'my-other-input'], [], [], true);
+      const component = createAngularComponentDefinition('my-component', [{name: 'my-input', required: false}, {name: 'my-other-input', required: false}], [], [], true);
 
       expect(component).toEqual(`@ProxyCmp({
   defineCustomElementFn: defineMyComponent,
@@ -138,6 +160,30 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['my-input', 'my-other-input'],
+  standalone: false
+})
+export class MyComponent {
+  protected el: HTMLMyComponentElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}`);
+    });
+
+    it('generates a component with inputs (required)', () => {
+      const component = createAngularComponentDefinition('my-component', [{name: 'my-input', required: true}, {name: 'my-other-input', required: false}], [], [], true);
+
+      expect(component).toEqual(`@ProxyCmp({
+  defineCustomElementFn: defineMyComponent,
+  inputs: ['my-input', 'my-other-input']
+})
+@Component({
+  selector: 'my-component',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: [{ name: 'my-input', required: true }, 'my-other-input'],
   standalone: false
 })
 export class MyComponent {
@@ -227,7 +273,7 @@ export class MyComponent {
 
   describe('inline members', () => {
     it('generates component with inlined member with jsDoc', () => {
-      const component = createAngularComponentDefinition('my-component', ['myMember'], [], [], false, false, [
+      const component = createAngularComponentDefinition('my-component', [{name: 'myMember', required: false}], [], [], false, false, [
         {
           docs: {
             tags: [{ name: 'deprecated', text: 'use v2 of this API' }],


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: https://github.com/stenciljs/output-targets/issues/656

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Angular component inputs are marked when prop in Stencil is required ([Required properties](https://stenciljs.com/docs/properties#required-properties)).

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
