### PR TITLE
fix(react): improved SSR for Next.js

### DIFF
--- a/example-project/component-library-angular/projects/library/package.json
+++ b/example-project/component-library-angular/projects/library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-library-angular",
-  "version": "0.0.1",
+  "private": true,
   "peerDependencies": {
     "@angular/common": "^20.0.0",
     "@angular/core": "^20.0.0"

--- a/example-project/component-library-angular/projects/library/test/my-input.spec.ts
+++ b/example-project/component-library-angular/projects/library/test/my-input.spec.ts
@@ -107,7 +107,6 @@ describe('MyInput - Disabled state', () => {
   });
 
   it('should support setting disabled state via the ValueAccessor', () => {
-    console.log(myInputEl.nativeElement);
     expect(myInputEl.nativeElement.disabled).toBe(true);
   });
 });

--- a/example-project/component-library-react/package.json
+++ b/example-project/component-library-react/package.json
@@ -6,7 +6,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": "./dist/components.server.js",
       "import": "./dist/index.js"
     },
     "./next": {
@@ -26,6 +25,14 @@
     "@stencil/react-output-target": "workspace:*",
     "component-library": "workspace:*",
     "react-dom": "^18.3.1"
+  },
+  "peerDependencies": {
+    "next": "^15.1.6"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^22.13.9",

--- a/example-project/component-library-react/package.json
+++ b/example-project/component-library-react/package.json
@@ -25,14 +25,6 @@
     "component-library": "workspace:*",
     "react-dom": "^18.3.1"
   },
-  "peerDependencies": {
-    "next": "^15.1.6"
-  },
-  "peerDependenciesMeta": {
-    "next": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/node": "^22.13.9",
     "@types/react": "^18",

--- a/example-project/component-library-react/package.json
+++ b/example-project/component-library-react/package.json
@@ -1,7 +1,6 @@
 {
   "name": "component-library-react",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "exports": {
     ".": {

--- a/example-project/component-library-react/src/components.server.ts
+++ b/example-project/component-library-react/src/components.server.ts
@@ -8,27 +8,27 @@
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
 import { createComponent, type HydrateModule, type ReactWebComponent, type SerializeShadowRootOptions } from '@stencil/react-output-target/ssr';
 import { type CheckboxChangeEventDetail, type IMyComponent, type InputChangeEventDetail, type MyCheckboxCustomEvent, type MyComponentScopedCustomEvent, type MyInputCustomEvent, type MyInputScopedCustomEvent, type MyPopoverCustomEvent, type MyRadioGroupCustomEvent, type MyRangeCustomEvent, type OverlayEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail } from "component-library";
-import { MyButtonScoped as MyButtonScopedElement, defineCustomElement as defineMyButtonScoped } from "component-library/components/my-button-scoped.js";
-import { MyButton as MyButtonElement, defineCustomElement as defineMyButton } from "component-library/components/my-button.js";
-import { MyCheckbox as MyCheckboxElement, defineCustomElement as defineMyCheckbox } from "component-library/components/my-checkbox.js";
-import { MyComplexPropsScoped as MyComplexPropsScopedElement, defineCustomElement as defineMyComplexPropsScoped } from "component-library/components/my-complex-props-scoped.js";
-import { MyComplexProps as MyComplexPropsElement, defineCustomElement as defineMyComplexProps } from "component-library/components/my-complex-props.js";
-import { MyComponentScoped as MyComponentScopedElement, defineCustomElement as defineMyComponentScoped } from "component-library/components/my-component-scoped.js";
-import { MyComponent as MyComponentElement, defineCustomElement as defineMyComponent } from "component-library/components/my-component.js";
-import { MyCounter as MyCounterElement, defineCustomElement as defineMyCounter } from "component-library/components/my-counter.js";
-import { MyInputScoped as MyInputScopedElement, defineCustomElement as defineMyInputScoped } from "component-library/components/my-input-scoped.js";
-import { MyInput as MyInputElement, defineCustomElement as defineMyInput } from "component-library/components/my-input.js";
-import { MyListItemScoped as MyListItemScopedElement, defineCustomElement as defineMyListItemScoped } from "component-library/components/my-list-item-scoped.js";
-import { MyListItem as MyListItemElement, defineCustomElement as defineMyListItem } from "component-library/components/my-list-item.js";
-import { MyListScoped as MyListScopedElement, defineCustomElement as defineMyListScoped } from "component-library/components/my-list-scoped.js";
-import { MyList as MyListElement, defineCustomElement as defineMyList } from "component-library/components/my-list.js";
-import { MyPopover as MyPopoverElement, defineCustomElement as defineMyPopover } from "component-library/components/my-popover.js";
-import { MyRadioGroup as MyRadioGroupElement, defineCustomElement as defineMyRadioGroup } from "component-library/components/my-radio-group.js";
-import { MyRadio as MyRadioElement, defineCustomElement as defineMyRadio } from "component-library/components/my-radio.js";
-import { MyRange as MyRangeElement, defineCustomElement as defineMyRange } from "component-library/components/my-range.js";
-import { MyToggleContent as MyToggleContentElement, defineCustomElement as defineMyToggleContent } from "component-library/components/my-toggle-content.js";
-import { MyToggle as MyToggleElement, defineCustomElement as defineMyToggle } from "component-library/components/my-toggle.js";
-import React from 'react';
+import { MyButtonScoped as MyButtonScopedElement } from "component-library/components/my-button-scoped.js";
+import { MyButton as MyButtonElement } from "component-library/components/my-button.js";
+import { MyCheckbox as MyCheckboxElement } from "component-library/components/my-checkbox.js";
+import { MyComplexPropsScoped as MyComplexPropsScopedElement } from "component-library/components/my-complex-props-scoped.js";
+import { MyComplexProps as MyComplexPropsElement } from "component-library/components/my-complex-props.js";
+import { MyComponentScoped as MyComponentScopedElement } from "component-library/components/my-component-scoped.js";
+import { MyComponent as MyComponentElement } from "component-library/components/my-component.js";
+import { MyCounter as MyCounterElement } from "component-library/components/my-counter.js";
+import { MyInputScoped as MyInputScopedElement } from "component-library/components/my-input-scoped.js";
+import { MyInput as MyInputElement } from "component-library/components/my-input.js";
+import { MyListItemScoped as MyListItemScopedElement } from "component-library/components/my-list-item-scoped.js";
+import { MyListItem as MyListItemElement } from "component-library/components/my-list-item.js";
+import { MyListScoped as MyListScopedElement } from "component-library/components/my-list-scoped.js";
+import { MyList as MyListElement } from "component-library/components/my-list.js";
+import { MyPopover as MyPopoverElement } from "component-library/components/my-popover.js";
+import { MyRadioGroup as MyRadioGroupElement } from "component-library/components/my-radio-group.js";
+import { MyRadio as MyRadioElement } from "component-library/components/my-radio.js";
+import { MyRange as MyRangeElement } from "component-library/components/my-range.js";
+import { MyToggleContent as MyToggleContentElement } from "component-library/components/my-toggle-content.js";
+import { MyToggle as MyToggleElement } from "component-library/components/my-toggle.js";
+import * as clientComponents from './components.js';
 
 export const serializeShadowRoot: SerializeShadowRootOptions = { "scoped": ["my-counter"], "default": "declarative-shadow-dom" };
 
@@ -55,20 +55,8 @@ export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents> = 
         type: 'type'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyButton as ReactWebComponent<MyButtonElement, MyButtonEvents>,
     serializeShadowRoot,
-    elementClass: MyButtonElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onMyFocus: 'myFocus',
-        onMyBlur: 'myBlur'
-    } as MyButtonEvents,
-    defineCustomElement: defineMyButton,
 });
 
 export type MyButtonScopedEvents = {
@@ -94,20 +82,8 @@ export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButt
         type: 'type'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyButtonScoped as ReactWebComponent<MyButtonScopedElement, MyButtonScopedEvents>,
     serializeShadowRoot,
-    elementClass: MyButtonScopedElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onMyFocus: 'myFocus',
-        onMyBlur: 'myBlur'
-    } as MyButtonScopedEvents,
-    defineCustomElement: defineMyButtonScoped,
 });
 
 export type MyCheckboxEvents = {
@@ -130,21 +106,8 @@ export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEven
         alignment: 'alignment'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyCheckbox as ReactWebComponent<MyCheckboxElement, MyCheckboxEvents>,
     serializeShadowRoot,
-    elementClass: MyCheckboxElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onIonChange: 'ionChange',
-        onIonFocus: 'ionFocus',
-        onIonBlur: 'ionBlur'
-    } as MyCheckboxEvents,
-    defineCustomElement: defineMyCheckbox,
 });
 
 export type MyComplexPropsEvents = NonNullable<unknown>;
@@ -159,17 +122,8 @@ export const MyComplexProps: StencilReactComponent<MyComplexPropsElement, MyComp
         waldo: 'waldo'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyComplexProps as ReactWebComponent<MyComplexPropsElement, MyComplexPropsEvents>,
     serializeShadowRoot,
-    elementClass: MyComplexPropsElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyComplexPropsEvents,
-    defineCustomElement: defineMyComplexProps,
 });
 
 export type MyComplexPropsScopedEvents = NonNullable<unknown>;
@@ -184,17 +138,8 @@ export const MyComplexPropsScoped: StencilReactComponent<MyComplexPropsScopedEle
         waldo: 'waldo'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyComplexPropsScoped as ReactWebComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents>,
     serializeShadowRoot,
-    elementClass: MyComplexPropsScopedElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyComplexPropsScopedEvents,
-    defineCustomElement: defineMyComplexPropsScoped,
 });
 
 export type MyComponentEvents = NonNullable<unknown>;
@@ -207,17 +152,8 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
         last: 'last'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyComponent as ReactWebComponent<MyComponentElement, MyComponentEvents>,
     serializeShadowRoot,
-    elementClass: MyComponentElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyComponentEvents,
-    defineCustomElement: defineMyComponent,
 });
 
 export type MyComponentScopedEvents = { onMyCustomEvent: EventName<MyComponentScopedCustomEvent<IMyComponent.someVar>> };
@@ -230,17 +166,8 @@ export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, 
         last: 'last'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyComponentScoped as ReactWebComponent<MyComponentScopedElement, MyComponentScopedEvents>,
     serializeShadowRoot,
-    elementClass: MyComponentScopedElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onMyCustomEvent: 'myCustomEvent' } as MyComponentScopedEvents,
-    defineCustomElement: defineMyComponentScoped,
 });
 
 export type MyCounterEvents = { onCount: EventName<CustomEvent<number>> };
@@ -249,17 +176,8 @@ export const MyCounter: StencilReactComponent<MyCounterElement, MyCounterEvents>
     tagName: 'my-counter',
     properties: { startValue: 'start-value' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyCounter as ReactWebComponent<MyCounterElement, MyCounterEvents>,
     serializeShadowRoot,
-    elementClass: MyCounterElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onCount: 'count' } as MyCounterEvents,
-    defineCustomElement: defineMyCounter,
 });
 
 export type MyInputEvents = {
@@ -300,22 +218,8 @@ export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = /*@
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyInput as ReactWebComponent<MyInputElement, MyInputEvents>,
     serializeShadowRoot,
-    elementClass: MyInputElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onMyInput: 'myInput',
-        onMyChange: 'myChange',
-        onMyBlur: 'myBlur',
-        onMyFocus: 'myFocus'
-    } as MyInputEvents,
-    defineCustomElement: defineMyInput,
 });
 
 export type MyInputScopedEvents = {
@@ -356,22 +260,8 @@ export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputS
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyInputScoped as ReactWebComponent<MyInputScopedElement, MyInputScopedEvents>,
     serializeShadowRoot,
-    elementClass: MyInputScopedElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onMyInput: 'myInput',
-        onMyChange: 'myChange',
-        onMyBlur: 'myBlur',
-        onMyFocus: 'myFocus'
-    } as MyInputScopedEvents,
-    defineCustomElement: defineMyInputScoped,
 });
 
 export type MyListEvents = NonNullable<unknown>;
@@ -380,17 +270,8 @@ export const MyList: StencilReactComponent<MyListElement, MyListEvents> = /*@__P
     tagName: 'my-list',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyList as ReactWebComponent<MyListElement, MyListEvents>,
     serializeShadowRoot,
-    elementClass: MyListElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyListEvents,
-    defineCustomElement: defineMyList,
 });
 
 export type MyListItemEvents = NonNullable<unknown>;
@@ -399,17 +280,8 @@ export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEven
     tagName: 'my-list-item',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyListItem as ReactWebComponent<MyListItemElement, MyListItemEvents>,
     serializeShadowRoot,
-    elementClass: MyListItemElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyListItemEvents,
-    defineCustomElement: defineMyListItem,
 });
 
 export type MyListItemScopedEvents = NonNullable<unknown>;
@@ -418,17 +290,8 @@ export const MyListItemScoped: StencilReactComponent<MyListItemScopedElement, My
     tagName: 'my-list-item-scoped',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyListItemScoped as ReactWebComponent<MyListItemScopedElement, MyListItemScopedEvents>,
     serializeShadowRoot,
-    elementClass: MyListItemScopedElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyListItemScopedEvents,
-    defineCustomElement: defineMyListItemScoped,
 });
 
 export type MyListScopedEvents = NonNullable<unknown>;
@@ -437,17 +300,8 @@ export const MyListScoped: StencilReactComponent<MyListScopedElement, MyListScop
     tagName: 'my-list-scoped',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyListScoped as ReactWebComponent<MyListScopedElement, MyListScopedEvents>,
     serializeShadowRoot,
-    elementClass: MyListScopedElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyListScopedEvents,
-    defineCustomElement: defineMyListScoped,
 });
 
 export type MyPopoverEvents = {
@@ -471,22 +325,8 @@ export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents>
         animated: 'animated'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyPopover as ReactWebComponent<MyPopoverElement, MyPopoverEvents>,
     serializeShadowRoot,
-    elementClass: MyPopoverElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onMyPopoverDidPresent: 'myPopoverDidPresent',
-        onMyPopoverWillPresent: 'myPopoverWillPresent',
-        onMyPopoverWillDismiss: 'myPopoverWillDismiss',
-        onMyPopoverDidDismiss: 'myPopoverDidDismiss'
-    } as MyPopoverEvents,
-    defineCustomElement: defineMyPopover,
 });
 
 export type MyRadioEvents = {
@@ -506,20 +346,8 @@ export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents> = /*@
         alignment: 'alignment'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyRadio as ReactWebComponent<MyRadioElement, MyRadioEvents>,
     serializeShadowRoot,
-    elementClass: MyRadioElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onIonFocus: 'ionFocus',
-        onIonBlur: 'ionBlur'
-    } as MyRadioEvents,
-    defineCustomElement: defineMyRadio,
 });
 
 export type MyRadioGroupEvents = { onMyChange: EventName<MyRadioGroupCustomEvent<RadioGroupChangeEventDetail>> };
@@ -533,17 +361,8 @@ export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGro
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyRadioGroup as ReactWebComponent<MyRadioGroupElement, MyRadioGroupEvents>,
     serializeShadowRoot,
-    elementClass: MyRadioGroupElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onMyChange: 'myChange' } as MyRadioGroupEvents,
-    defineCustomElement: defineMyRadioGroup,
 });
 
 export type MyRangeEvents = {
@@ -569,21 +388,8 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = /*@
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyRange as ReactWebComponent<MyRangeElement, MyRangeEvents>,
     serializeShadowRoot,
-    elementClass: MyRangeElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onMyChange: 'myChange',
-        onMyFocus: 'myFocus',
-        onMyBlur: 'myBlur'
-    } as MyRangeEvents,
-    defineCustomElement: defineMyRange,
 });
 
 export type MyToggleEvents = NonNullable<unknown>;
@@ -592,17 +398,8 @@ export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents> = 
     tagName: 'my-toggle',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyToggle as ReactWebComponent<MyToggleElement, MyToggleEvents>,
     serializeShadowRoot,
-    elementClass: MyToggleElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyToggleEvents,
-    defineCustomElement: defineMyToggle,
 });
 
 export type MyToggleContentEvents = NonNullable<unknown>;
@@ -611,15 +408,6 @@ export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyTo
     tagName: 'my-toggle-content',
     properties: { visible: 'visible' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
+    clientModule: clientComponents.MyToggleContent as ReactWebComponent<MyToggleContentElement, MyToggleContentEvents>,
     serializeShadowRoot,
-    elementClass: MyToggleContentElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyToggleContentEvents,
-    defineCustomElement: defineMyToggleContent,
 });

--- a/example-project/component-library-react/src/components.server.ts
+++ b/example-project/component-library-react/src/components.server.ts
@@ -6,10 +6,11 @@
 /* eslint-disable */
 
 // @ts-ignore - ignore potential type issues as the project is importing itself
+import * as clientComponents from 'component-library-react';
+
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
 import { createComponent, type HydrateModule, type ReactWebComponent, type SerializeShadowRootOptions } from '@stencil/react-output-target/ssr';
 import { type CheckboxChangeEventDetail, type IMyComponent, type InputChangeEventDetail, type MyCheckboxCustomEvent, type MyComponentScopedCustomEvent, type MyInputCustomEvent, type MyInputScopedCustomEvent, type MyPopoverCustomEvent, type MyRadioGroupCustomEvent, type MyRangeCustomEvent, type OverlayEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail } from "component-library";
-import * as clientComponents from 'component-library-react';
 import { MyButtonScoped as MyButtonScopedElement } from "component-library/components/my-button-scoped.js";
 import { MyButton as MyButtonElement } from "component-library/components/my-button.js";
 import { MyCheckbox as MyCheckboxElement } from "component-library/components/my-checkbox.js";

--- a/example-project/component-library-react/src/components.server.ts
+++ b/example-project/component-library-react/src/components.server.ts
@@ -5,6 +5,7 @@
 
 /* eslint-disable */
 
+// @ts-ignore - ignore potential type issues as the project is importing itself
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
 import { createComponent, type HydrateModule, type ReactWebComponent, type SerializeShadowRootOptions } from '@stencil/react-output-target/ssr';
 import { type CheckboxChangeEventDetail, type IMyComponent, type InputChangeEventDetail, type MyCheckboxCustomEvent, type MyComponentScopedCustomEvent, type MyInputCustomEvent, type MyInputScopedCustomEvent, type MyPopoverCustomEvent, type MyRadioGroupCustomEvent, type MyRangeCustomEvent, type OverlayEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail } from "component-library";

--- a/example-project/component-library-react/src/components.server.ts
+++ b/example-project/component-library-react/src/components.server.ts
@@ -6,7 +6,7 @@
 /* eslint-disable */
 
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
-import { createComponent, type HydrateModule, type SerializeShadowRootOptions } from '@stencil/react-output-target/ssr';
+import { createComponent, type HydrateModule, type ReactWebComponent, type SerializeShadowRootOptions } from '@stencil/react-output-target/ssr';
 import { type CheckboxChangeEventDetail, type IMyComponent, type InputChangeEventDetail, type MyCheckboxCustomEvent, type MyComponentScopedCustomEvent, type MyInputCustomEvent, type MyInputScopedCustomEvent, type MyPopoverCustomEvent, type MyRadioGroupCustomEvent, type MyRangeCustomEvent, type OverlayEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail } from "component-library";
 import { MyButtonScoped as MyButtonScopedElement, defineCustomElement as defineMyButtonScoped } from "component-library/components/my-button-scoped.js";
 import { MyButton as MyButtonElement, defineCustomElement as defineMyButton } from "component-library/components/my-button.js";
@@ -55,6 +55,7 @@ export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents> = 
         type: 'type'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyButtonElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -63,7 +64,7 @@ export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents> = 
         onMyFocus: 'myFocus',
         onMyBlur: 'myBlur'
     } as MyButtonEvents,
-    defineCustomElement: defineMyButton
+    defineCustomElement: defineMyButton,
 });
 
 export type MyButtonScopedEvents = {
@@ -89,6 +90,7 @@ export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButt
         type: 'type'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyButtonScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -97,7 +99,7 @@ export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButt
         onMyFocus: 'myFocus',
         onMyBlur: 'myBlur'
     } as MyButtonScopedEvents,
-    defineCustomElement: defineMyButtonScoped
+    defineCustomElement: defineMyButtonScoped,
 });
 
 export type MyCheckboxEvents = {
@@ -120,6 +122,7 @@ export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEven
         alignment: 'alignment'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyCheckboxElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -129,7 +132,7 @@ export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEven
         onIonFocus: 'ionFocus',
         onIonBlur: 'ionBlur'
     } as MyCheckboxEvents,
-    defineCustomElement: defineMyCheckbox
+    defineCustomElement: defineMyCheckbox,
 });
 
 export type MyComplexPropsEvents = NonNullable<unknown>;
@@ -144,12 +147,13 @@ export const MyComplexProps: StencilReactComponent<MyComplexPropsElement, MyComp
         waldo: 'waldo'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyComplexPropsElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyComplexPropsEvents,
-    defineCustomElement: defineMyComplexProps
+    defineCustomElement: defineMyComplexProps,
 });
 
 export type MyComplexPropsScopedEvents = NonNullable<unknown>;
@@ -164,12 +168,13 @@ export const MyComplexPropsScoped: StencilReactComponent<MyComplexPropsScopedEle
         waldo: 'waldo'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyComplexPropsScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyComplexPropsScopedEvents,
-    defineCustomElement: defineMyComplexPropsScoped
+    defineCustomElement: defineMyComplexPropsScoped,
 });
 
 export type MyComponentEvents = NonNullable<unknown>;
@@ -182,12 +187,13 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
         last: 'last'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyComponentEvents,
-    defineCustomElement: defineMyComponent
+    defineCustomElement: defineMyComponent,
 });
 
 export type MyComponentScopedEvents = { onMyCustomEvent: EventName<MyComponentScopedCustomEvent<IMyComponent.someVar>> };
@@ -200,12 +206,13 @@ export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, 
         last: 'last'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyComponentScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onMyCustomEvent: 'myCustomEvent' } as MyComponentScopedEvents,
-    defineCustomElement: defineMyComponentScoped
+    defineCustomElement: defineMyComponentScoped,
 });
 
 export type MyCounterEvents = { onCount: EventName<CustomEvent<number>> };
@@ -214,12 +221,13 @@ export const MyCounter: StencilReactComponent<MyCounterElement, MyCounterEvents>
     tagName: 'my-counter',
     properties: { startValue: 'start-value' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyCounterElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onCount: 'count' } as MyCounterEvents,
-    defineCustomElement: defineMyCounter
+    defineCustomElement: defineMyCounter,
 });
 
 export type MyInputEvents = {
@@ -260,6 +268,7 @@ export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = /*@
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyInputElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -270,7 +279,7 @@ export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = /*@
         onMyBlur: 'myBlur',
         onMyFocus: 'myFocus'
     } as MyInputEvents,
-    defineCustomElement: defineMyInput
+    defineCustomElement: defineMyInput,
 });
 
 export type MyInputScopedEvents = {
@@ -311,6 +320,7 @@ export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputS
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyInputScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -321,7 +331,7 @@ export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputS
         onMyBlur: 'myBlur',
         onMyFocus: 'myFocus'
     } as MyInputScopedEvents,
-    defineCustomElement: defineMyInputScoped
+    defineCustomElement: defineMyInputScoped,
 });
 
 export type MyListEvents = NonNullable<unknown>;
@@ -330,12 +340,13 @@ export const MyList: StencilReactComponent<MyListElement, MyListEvents> = /*@__P
     tagName: 'my-list',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyListElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyListEvents,
-    defineCustomElement: defineMyList
+    defineCustomElement: defineMyList,
 });
 
 export type MyListItemEvents = NonNullable<unknown>;
@@ -344,12 +355,13 @@ export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEven
     tagName: 'my-list-item',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyListItemElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyListItemEvents,
-    defineCustomElement: defineMyListItem
+    defineCustomElement: defineMyListItem,
 });
 
 export type MyListItemScopedEvents = NonNullable<unknown>;
@@ -358,12 +370,13 @@ export const MyListItemScoped: StencilReactComponent<MyListItemScopedElement, My
     tagName: 'my-list-item-scoped',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyListItemScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyListItemScopedEvents,
-    defineCustomElement: defineMyListItemScoped
+    defineCustomElement: defineMyListItemScoped,
 });
 
 export type MyListScopedEvents = NonNullable<unknown>;
@@ -372,12 +385,13 @@ export const MyListScoped: StencilReactComponent<MyListScopedElement, MyListScop
     tagName: 'my-list-scoped',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyListScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyListScopedEvents,
-    defineCustomElement: defineMyListScoped
+    defineCustomElement: defineMyListScoped,
 });
 
 export type MyPopoverEvents = {
@@ -401,6 +415,7 @@ export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents>
         animated: 'animated'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyPopoverElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -411,7 +426,7 @@ export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents>
         onMyPopoverWillDismiss: 'myPopoverWillDismiss',
         onMyPopoverDidDismiss: 'myPopoverDidDismiss'
     } as MyPopoverEvents,
-    defineCustomElement: defineMyPopover
+    defineCustomElement: defineMyPopover,
 });
 
 export type MyRadioEvents = {
@@ -431,6 +446,7 @@ export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents> = /*@
         alignment: 'alignment'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyRadioElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -439,7 +455,7 @@ export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents> = /*@
         onIonFocus: 'ionFocus',
         onIonBlur: 'ionBlur'
     } as MyRadioEvents,
-    defineCustomElement: defineMyRadio
+    defineCustomElement: defineMyRadio,
 });
 
 export type MyRadioGroupEvents = { onMyChange: EventName<MyRadioGroupCustomEvent<RadioGroupChangeEventDetail>> };
@@ -453,12 +469,13 @@ export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGro
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyRadioGroupElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onMyChange: 'myChange' } as MyRadioGroupEvents,
-    defineCustomElement: defineMyRadioGroup
+    defineCustomElement: defineMyRadioGroup,
 });
 
 export type MyRangeEvents = {
@@ -484,6 +501,7 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = /*@
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyRangeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -493,7 +511,7 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = /*@
         onMyFocus: 'myFocus',
         onMyBlur: 'myBlur'
     } as MyRangeEvents,
-    defineCustomElement: defineMyRange
+    defineCustomElement: defineMyRange,
 });
 
 export type MyToggleEvents = NonNullable<unknown>;
@@ -502,12 +520,13 @@ export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents> = 
     tagName: 'my-toggle',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyToggleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyToggleEvents,
-    defineCustomElement: defineMyToggle
+    defineCustomElement: defineMyToggle,
 });
 
 export type MyToggleContentEvents = NonNullable<unknown>;
@@ -516,10 +535,11 @@ export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyTo
     tagName: 'my-toggle-content',
     properties: { visible: 'visible' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyToggleContentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyToggleContentEvents,
-    defineCustomElement: defineMyToggleContent
+    defineCustomElement: defineMyToggleContent,
 });

--- a/example-project/component-library-react/src/components.server.ts
+++ b/example-project/component-library-react/src/components.server.ts
@@ -55,7 +55,11 @@ export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents> = 
         type: 'type'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyButtonElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -90,7 +94,11 @@ export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButt
         type: 'type'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyButtonScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -122,7 +130,11 @@ export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEven
         alignment: 'alignment'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyCheckboxElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -147,7 +159,11 @@ export const MyComplexProps: StencilReactComponent<MyComplexPropsElement, MyComp
         waldo: 'waldo'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyComplexPropsElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -168,7 +184,11 @@ export const MyComplexPropsScoped: StencilReactComponent<MyComplexPropsScopedEle
         waldo: 'waldo'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyComplexPropsScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -187,7 +207,11 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
         last: 'last'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -206,7 +230,11 @@ export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, 
         last: 'last'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyComponentScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -221,7 +249,11 @@ export const MyCounter: StencilReactComponent<MyCounterElement, MyCounterEvents>
     tagName: 'my-counter',
     properties: { startValue: 'start-value' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyCounterElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -268,7 +300,11 @@ export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents> = /*@
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyInputElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -320,7 +356,11 @@ export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputS
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyInputScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -340,7 +380,11 @@ export const MyList: StencilReactComponent<MyListElement, MyListEvents> = /*@__P
     tagName: 'my-list',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyListElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -355,7 +399,11 @@ export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEven
     tagName: 'my-list-item',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyListItemElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -370,7 +418,11 @@ export const MyListItemScoped: StencilReactComponent<MyListItemScopedElement, My
     tagName: 'my-list-item-scoped',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyListItemScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -385,7 +437,11 @@ export const MyListScoped: StencilReactComponent<MyListScopedElement, MyListScop
     tagName: 'my-list-scoped',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyListScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -415,7 +471,11 @@ export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents>
         animated: 'animated'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyPopoverElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -446,7 +506,11 @@ export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents> = /*@
         alignment: 'alignment'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyRadioElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -469,7 +533,11 @@ export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGro
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyRadioGroupElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -501,7 +569,11 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents> = /*@
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyRangeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -520,7 +592,11 @@ export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents> = 
     tagName: 'my-toggle',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyToggleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -535,7 +611,11 @@ export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyTo
     tagName: 'my-toggle-content',
     properties: { visible: 'visible' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyToggleContentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.

--- a/example-project/component-library-react/src/components.server.ts
+++ b/example-project/component-library-react/src/components.server.ts
@@ -8,6 +8,7 @@
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
 import { createComponent, type HydrateModule, type ReactWebComponent, type SerializeShadowRootOptions } from '@stencil/react-output-target/ssr';
 import { type CheckboxChangeEventDetail, type IMyComponent, type InputChangeEventDetail, type MyCheckboxCustomEvent, type MyComponentScopedCustomEvent, type MyInputCustomEvent, type MyInputScopedCustomEvent, type MyPopoverCustomEvent, type MyRadioGroupCustomEvent, type MyRangeCustomEvent, type OverlayEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail } from "component-library";
+import * as clientComponents from 'component-library-react';
 import { MyButtonScoped as MyButtonScopedElement } from "component-library/components/my-button-scoped.js";
 import { MyButton as MyButtonElement } from "component-library/components/my-button.js";
 import { MyCheckbox as MyCheckboxElement } from "component-library/components/my-checkbox.js";
@@ -28,7 +29,6 @@ import { MyRadio as MyRadioElement } from "component-library/components/my-radio
 import { MyRange as MyRangeElement } from "component-library/components/my-range.js";
 import { MyToggleContent as MyToggleContentElement } from "component-library/components/my-toggle-content.js";
 import { MyToggle as MyToggleElement } from "component-library/components/my-toggle.js";
-import * as clientComponents from './components.js';
 
 export const serializeShadowRoot: SerializeShadowRootOptions = { "scoped": ["my-counter"], "default": "declarative-shadow-dom" };
 

--- a/example-project/component-library-react/tsconfig.json
+++ b/example-project/component-library-react/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./dist",
     "declaration": true,
     "declarationDir": "./dist",
-    "rootDir": ".",
+    "rootDir": "./src",
     "strict": true
   }
 }

--- a/example-project/component-library-react/tsconfig.json
+++ b/example-project/component-library-react/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "./dist",
     "declaration": true,
     "declarationDir": "./dist",
+    "rootDir": ".",
     "strict": true
   }
 }

--- a/example-project/component-library-vue/package.json
+++ b/example-project/component-library-vue/package.json
@@ -1,7 +1,6 @@
 {
   "name": "component-library-vue",
   "sideEffects": false,
-  "version": "0.0.1",
   "private": true,
   "description": "Vue specific wrapper for component-library",
   "repository": {

--- a/example-project/component-library/package.json
+++ b/example-project/component-library/package.json
@@ -1,6 +1,5 @@
 {
   "name": "component-library",
-  "version": "0.0.4",
   "private": true,
   "description": "Stencil Component Library for testing purposes",
   "license": "MIT",

--- a/example-project/component-library/stencil.config.ts
+++ b/example-project/component-library/stencil.config.ts
@@ -67,6 +67,7 @@ export const config: Config = {
     reactOutputTarget({
       outDir: '../component-library-react/src',
       hydrateModule: 'component-library/hydrate',
+      clientModule: 'component-library-react',
       serializeShadowRoot: { scoped: ['my-counter'], default: 'declarative-shadow-dom' }
     }),
     vueOutputTarget({

--- a/example-project/next-15-react-19-app/package.json
+++ b/example-project/next-15-react-19-app/package.json
@@ -1,6 +1,5 @@
 {
   "name": "next-15-react-19-app",
-  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/example-project/next-15-runtime-based/package.json
+++ b/example-project/next-15-runtime-based/package.json
@@ -1,6 +1,5 @@
 {
   "name": "next-15-runtime-based",
-  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/example-project/next-15-runtime-based/test/__snapshots__/test.e2e.ts.snap
+++ b/example-project/next-15-runtime-based/test/__snapshots__/test.e2e.ts.snap
@@ -3,6 +3,11 @@
 exports[`complex-props-scoped > should correctly server side render complex props 1`] = `
 "
 <div id="complex-props-scoped">
+  <template
+    data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+    data-msg="..."
+  >
+  </template>
   <my-complex-props-scoped
     baz="serialized:eyJ0eXBlIjoibWFwIiwidmFsdWUiOltbeyJ0eXBlIjoic3RyaW5nIiwidmFsdWUiOiJmb28ifSx7InR5cGUiOiJvYmplY3QiLCJ2YWx1ZSI6W1sicXV4Iix7InR5cGUiOiJzeW1ib2wiLCJ2YWx1ZSI6InF1dXgifV1dfV1dfQ=="
     class="hydrated sc-my-complex-props-scoped-h"
@@ -67,6 +72,11 @@ exports[`complex-props-scoped > should correctly server side render complex prop
 exports[`complex-props-shadow > should correctly server side render complex props 1`] = `
 "
 <div id="complex-props-shadow">
+  <template
+    data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+    data-msg="..."
+  >
+  </template>
   <my-complex-props
     baz="serialized:eyJ0eXBlIjoibWFwIiwidmFsdWUiOltbeyJ0eXBlIjoic3RyaW5nIiwidmFsdWUiOiJmb28ifSx7InR5cGUiOiJvYmplY3QiLCJ2YWx1ZSI6W1sicXV4Iix7InR5cGUiOiJzeW1ib2wiLCJ2YWx1ZSI6InF1dXgifV1dfV1dfQ=="
     class="hydrated sc-my-complex-props-h"
@@ -133,6 +143,11 @@ exports[`complex-props-shadow > should correctly server side render complex prop
 exports[`nested-shadow > should correctly server side render 1`] = `
 "
 <div id="nested-shadow">
+  <template
+    data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+    data-msg="..."
+  >
+  </template>
   <my-list
     class="hydrated sc-my-list-h"
     s-id="x"
@@ -148,6 +163,11 @@ exports[`nested-shadow > should correctly server side render 1`] = `
         >
         </slot>
       </ul>
+    </template>
+    <template
+      data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+      data-msg="..."
+    >
     </template>
     <my-list-item
       class="hydrated sc-my-list-item-h"
@@ -167,6 +187,11 @@ exports[`nested-shadow > should correctly server side render 1`] = `
       </template>
       Foo Shadow
     </my-list-item>
+    <template
+      data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+      data-msg="..."
+    >
+    </template>
     <my-list-item
       class="hydrated sc-my-list-item-h"
       s-id="x"
@@ -185,6 +210,11 @@ exports[`nested-shadow > should correctly server side render 1`] = `
       </template>
       Bar Shadow
     </my-list-item>
+    <template
+      data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+      data-msg="..."
+    >
+    </template>
     <my-list-item
       class="hydrated sc-my-list-item-h"
       s-id="x"
@@ -211,6 +241,14 @@ exports[`nested-shadow > should correctly server side render 1`] = `
 exports[`single-children-scoped > should correctly server side render 1`] = `
 "
 <div id="single-children-scoped">
+  <template
+    data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+    data-msg="..."
+  >
+  </template>
+  <style id="sc-my-button-scoped">
+    .sc-my-button-scoped-h{display:block;background-color:green;color:white;font-weight:bold;border-radius:5px;cursor:pointer}slot-fb{display:contents}slot-fb[hidden]{display:none}
+  </style>
   <my-button-scoped
     class="button button-outline hydrated my-activatable my-focusable sc-my-button-scoped-h"
     fill="outline"
@@ -236,6 +274,11 @@ exports[`single-children-scoped > should correctly server side render 1`] = `
 exports[`single-children-shadow > should correctly server side render 1`] = `
 "
 <div id="single-children-shadow">
+  <template
+    data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+    data-msg="..."
+  >
+  </template>
   <my-button
     class="button button-outline hydrated my-activatable my-focusable sc-my-button-h"
     fill="outline"
@@ -289,6 +332,14 @@ exports[`single-children-shadow > should correctly server side render 1`] = `
 exports[`single-no-child-scoped > should correctly server side render 1`] = `
 "
 <div id="single-no-child-scoped">
+  <template
+    data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+    data-msg="..."
+  >
+  </template>
+  <style id="sc-my-component-scoped">
+    .sc-my-component-scoped-h{display:block;color:green}
+  </style>
   <my-component-scoped
     class="hydrated sc-my-component-scoped-h"
     first="John"
@@ -310,6 +361,11 @@ exports[`single-no-child-scoped > should correctly server side render 1`] = `
 exports[`single-no-child-shadow > should correctly server side render 1`] = `
 "
 <div id="single-no-child-shadow">
+  <template
+    data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
+    data-msg="..."
+  >
+  </template>
   <my-component
     class="hydrated sc-my-component-h"
     first="John"
@@ -329,42 +385,6 @@ exports[`single-no-child-shadow > should correctly server side render 1`] = `
       </div>
     </template>
   </my-component>
-</div>
-"
-`;
-
-exports[`transform-scoped-to-shadow > should server side render component as scoped component 1`] = `
-"
-<div id="transform-scoped-to-shadow">
-  <my-counter
-    class="hydrated sc-my-counter-h"
-    s-id="x"
-    start-value="42"
-  >
-    <div
-      c-id="x"
-      class="sc-my-counter"
-    >
-      <button
-        c-id="x"
-        class="sc-my-counter"
-      >
-        -
-      </button>
-      <span
-        c-id="x"
-        class="sc-my-counter"
-      >
-        42
-      </span>
-      <button
-        c-id="x"
-        class="sc-my-counter"
-      >
-        +
-      </button>
-    </div>
-  </my-counter>
 </div>
 "
 `;

--- a/example-project/next-15-runtime-based/test/test.e2e.ts
+++ b/example-project/next-15-runtime-based/test/test.e2e.ts
@@ -1,5 +1,13 @@
 import { runTestScenarios } from 'react-test-components/scenarios';
 
 describe('Next 15 React 19 SSR Integration', () => {
-  runTestScenarios()
+  runTestScenarios({
+    /**
+     * We have to disable client side error checks as we
+     * can't guarantee no hydration errors are logged using
+     * the runtime based SSR approach.
+     */
+    assertClientSideErrors: false,
+    exclude: ['transform-scoped-to-shadow'],
+  })
 })

--- a/example-project/next-app/package.json
+++ b/example-project/next-app/package.json
@@ -1,6 +1,5 @@
 {
   "name": "next-app",
-  "version": "0.1.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/example-project/ng-app/package.json
+++ b/example-project/ng-app/package.json
@@ -1,6 +1,5 @@
 {
   "name": "ng-app",
-  "version": "0.0.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/example-project/react-app/package.json
+++ b/example-project/react-app/package.json
@@ -1,7 +1,6 @@
 {
   "name": "react-app",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "node server",

--- a/example-project/react-app/wdio.conf.ts
+++ b/example-project/react-app/wdio.conf.ts
@@ -43,6 +43,7 @@ export const config: WebdriverIO.Config = {
   // from the same test should run tests.
   //
   maxInstances: 10,
+  specFileRetries: 2,
   //
   // If you have trouble getting all important capabilities together, check out the
   // Sauce Labs platform configurator - a great tool to configure your capabilities:

--- a/example-project/react-app/wdio.conf.ts
+++ b/example-project/react-app/wdio.conf.ts
@@ -43,7 +43,6 @@ export const config: WebdriverIO.Config = {
   // from the same test should run tests.
   //
   maxInstances: 10,
-  specFileRetries: 2,
   //
   // If you have trouble getting all important capabilities together, check out the
   // Sauce Labs platform configurator - a great tool to configure your capabilities:

--- a/example-project/vue-app-broken/package.json
+++ b/example-project/vue-app-broken/package.json
@@ -1,7 +1,6 @@
 {
   "name": "vue-app-broken",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "build.app": "vue-tsc --noEmit -p ./tsconfig.json",

--- a/example-project/vue-app/package.json
+++ b/example-project/vue-app/package.json
@@ -1,7 +1,6 @@
 {
   "name": "vue-app",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/example-project/vue-app/src/components/Input.vue
+++ b/example-project/vue-app/src/components/Input.vue
@@ -12,7 +12,6 @@ export default defineComponent({
     const changeEvent = ref('');
 
     const handleChange = (ev) => {
-      console.log('handleChange', ev.target.value);
       changeEvent.value = ev.detail.value;
     };
 

--- a/example-project/vue-app/src/views/BasicComposition.vue
+++ b/example-project/vue-app/src/views/BasicComposition.vue
@@ -49,7 +49,6 @@ export default defineComponent({
     MyRadioGroup
   },
   setup() {
-    console.log('BasicComposition')
     const input = ref('')
     const isClicked = ref(false)
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "test.e2e.vue": "pnpm --filter vue-app test",
     "test.e2e.next": "pnpm --filter next-app test",
     "test.e2e.next-15": "pnpm --filter next-15-react-19-app test",
+    "test.e2e.runtime": "pnpm --filter next-15-runtime-based test",
     "test.e2e.nuxt": "pnpm --filter nuxt-app test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build.example.vue.app": "pnpm --filter vue-app run build",
     "build.example.nuxt": "pnpm --filter nuxt-app run build",
     "build.example.next-15": "pnpm --filter next-15-react-19-app run build",
+    "build.example.runtime": "pnpm --filter next-15-runtime-based run build",
     "changelog": "lerna-changelog",
     "clean": "lerna run clean",
     "dev": "run-p dev.*",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prettier.dry-run": "lerna run prettier.dry-run",
     "start.next-14": "pnpm --filter next-app run start",
     "start.next-15": "pnpm --filter next-15-react-19-app run start",
+    "start.next-runtime": "pnpm --filter next-15-runtime-based run start",
     "start.nuxt": "pnpm --filter nuxt-app run start",
     "start.vue": "pnpm --filter vue-app run dev",
     "test": "lerna run test",

--- a/packages/react/src/create-component-wrappers.test.ts
+++ b/packages/react/src/create-component-wrappers.test.ts
@@ -278,7 +278,11 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
     tagName: 'my-component',
     properties: { hasMaxLength: 'max-length' },
     hydrateModule: import('my-package/hydrate') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.

--- a/packages/react/src/create-component-wrappers.test.ts
+++ b/packages/react/src/create-component-wrappers.test.ts
@@ -278,12 +278,8 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
     tagName: 'my-component',
     properties: { hasMaxLength: 'max-length' },
     hydrateModule: import('my-package/hydrate') as Promise<HydrateModule>,
+    clientModule: clientComponents.MyComponent as ReactWebComponent<MyComponentElement, MyComponentEvents>,
     serializeShadowRoot,
-    elementClass: MyComponentElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as MyComponentEvents,
-    defineCustomElement: defineMyComponent,
 });
 `);
   });

--- a/packages/react/src/create-component-wrappers.test.ts
+++ b/packages/react/src/create-component-wrappers.test.ts
@@ -278,11 +278,6 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
     tagName: 'my-component',
     properties: { hasMaxLength: 'max-length' },
     hydrateModule: import('my-package/hydrate') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.

--- a/packages/react/src/create-component-wrappers.test.ts
+++ b/packages/react/src/create-component-wrappers.test.ts
@@ -278,12 +278,13 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
     tagName: 'my-component',
     properties: { hasMaxLength: 'max-length' },
     hydrateModule: import('my-package/hydrate') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as MyComponentEvents,
-    defineCustomElement: defineMyComponent
+    defineCustomElement: defineMyComponent,
 });
 `);
   });

--- a/packages/react/src/create-component-wrappers.ts
+++ b/packages/react/src/create-component-wrappers.ts
@@ -14,6 +14,7 @@ export const createComponentWrappers = async ({
   excludeComponents,
   project,
   hydrateModule,
+  clientModule,
   excludeServerSideRenderingFor,
   serializeShadowRoot,
 }: {
@@ -25,6 +26,7 @@ export const createComponentWrappers = async ({
   excludeComponents?: string[];
   project: Project;
   hydrateModule?: string;
+  clientModule?: string;
   excludeServerSideRenderingFor?: string[];
   serializeShadowRoot?: RenderToStringOptions['serializeShadowRoot'];
 }) => {
@@ -86,6 +88,7 @@ export const createComponentWrappers = async ({
         stencilPackageName,
         customElementsDir,
         hydrateModule,
+        clientModule,
         serializeShadowRoot,
       });
       fileContents[outputPath] = stencilReactComponent;

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -37,6 +37,7 @@ export const createStencilReactComponents = ({
   const disableEslint = `/* eslint-disable */\n`;
   const createComponentImport = hydrateModule
     ? [
+        `import * as clientComponents from './components.js';`,
         `import { createComponent, type SerializeShadowRootOptions, type HydrateModule, type ReactWebComponent, type DynamicFunction } from '@stencil/react-output-target/ssr';`,
       ].join('\n')
     : `import { createComponent } from '@stencil/react-output-target/runtime';`;
@@ -177,12 +178,8 @@ import type { EventName, StencilReactComponent } from '@stencil/react-output-tar
       .map((e) => `${e.name}: '${e.attribute}'`)
       .join(',\n')}},
     hydrateModule: import('${hydrateModule}') as Promise<HydrateModule>,
+    clientModule: clientComponents.${reactTagName} as ReactWebComponent<${componentElement}, ${componentEventNamesType}>,
     serializeShadowRoot,
-    elementClass: ${componentElement},
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {${events.map((e) => `${e.name}: '${e.originalName}'`).join(',\n')}} as ${componentEventNamesType},
-    defineCustomElement: define${reactTagName},
   })`;
 
     sourceFile.addVariableStatement({

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -36,7 +36,9 @@ export const createStencilReactComponents = ({
 
   const disableEslint = `/* eslint-disable */\n`;
   const createComponentImport = hydrateModule
-    ? `import { createComponent, type SerializeShadowRootOptions, type HydrateModule } from '@stencil/react-output-target/ssr';`
+    ? [
+      `import { createComponent, type SerializeShadowRootOptions, type HydrateModule, type ReactWebComponent, type DynamicFunction } from '@stencil/react-output-target/ssr';`
+    ].join('\n')
     : `import { createComponent } from '@stencil/react-output-target/runtime';`;
   const sourceFile = project.createSourceFile(
     'component.ts',
@@ -175,12 +177,13 @@ import type { EventName, StencilReactComponent } from '@stencil/react-output-tar
       .map((e) => `${e.name}: '${e.attribute}'`)
       .join(',\n')}},
     hydrateModule: import('${hydrateModule}') as Promise<HydrateModule>,
+    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
     serializeShadowRoot,
     elementClass: ${componentElement},
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {${events.map((e) => `${e.name}: '${e.originalName}'`).join(',\n')}} as ${componentEventNamesType},
-    defineCustomElement: define${reactTagName}
+    defineCustomElement: define${reactTagName},
   })`;
 
     sourceFile.addVariableStatement({

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -41,6 +41,7 @@ export const createStencilReactComponents = ({
     ? [
         `// @ts-ignore - ignore potential type issues as the project is importing itself`,
         `import * as clientComponents from '${clientModule}';`,
+        '',
         `import { createComponent, type SerializeShadowRootOptions, type HydrateModule, type ReactWebComponent, type DynamicFunction } from '@stencil/react-output-target/ssr';`,
       ].join('\n')
     : `import { createComponent } from '@stencil/react-output-target/runtime';`;

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -39,6 +39,7 @@ export const createStencilReactComponents = ({
   const disableEslint = `/* eslint-disable */\n`;
   const createComponentImport = hydrateModule
     ? [
+        `// @ts-ignore - ignore potential type issues as the project is importing itself`,
         `import * as clientComponents from '${clientModule}';`,
         `import { createComponent, type SerializeShadowRootOptions, type HydrateModule, type ReactWebComponent, type DynamicFunction } from '@stencil/react-output-target/ssr';`,
       ].join('\n')

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -177,11 +177,6 @@ import type { EventName, StencilReactComponent } from '@stencil/react-output-tar
       .map((e) => `${e.name}: '${e.attribute}'`)
       .join(',\n')}},
     hydrateModule: import('${hydrateModule}') as Promise<HydrateModule>,
-    /**
-     * We need to use a dynamic import to ensure we don't load the client module
-     * during the SSR build.
-     */
-    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: ${componentElement},
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -14,12 +14,14 @@ export const createStencilReactComponents = ({
   stencilPackageName,
   customElementsDir,
   hydrateModule,
+  clientModule,
   serializeShadowRoot,
 }: {
   components: ComponentCompilerMeta[];
   stencilPackageName: string;
   customElementsDir: string;
   hydrateModule?: string;
+  clientModule?: string;
   serializeShadowRoot?: RenderToStringOptions['serializeShadowRoot'];
 }) => {
   const project = new Project({ useInMemoryFileSystem: true });
@@ -37,7 +39,7 @@ export const createStencilReactComponents = ({
   const disableEslint = `/* eslint-disable */\n`;
   const createComponentImport = hydrateModule
     ? [
-        `import * as clientComponents from './components.js';`,
+        `import * as clientComponents from '${clientModule}';`,
         `import { createComponent, type SerializeShadowRootOptions, type HydrateModule, type ReactWebComponent, type DynamicFunction } from '@stencil/react-output-target/ssr';`,
       ].join('\n')
     : `import { createComponent } from '@stencil/react-output-target/runtime';`;

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -37,8 +37,8 @@ export const createStencilReactComponents = ({
   const disableEslint = `/* eslint-disable */\n`;
   const createComponentImport = hydrateModule
     ? [
-      `import { createComponent, type SerializeShadowRootOptions, type HydrateModule, type ReactWebComponent, type DynamicFunction } from '@stencil/react-output-target/ssr';`
-    ].join('\n')
+        `import { createComponent, type SerializeShadowRootOptions, type HydrateModule, type ReactWebComponent, type DynamicFunction } from '@stencil/react-output-target/ssr';`,
+      ].join('\n')
     : `import { createComponent } from '@stencil/react-output-target/runtime';`;
   const sourceFile = project.createSourceFile(
     'component.ts',

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -177,7 +177,11 @@ import type { EventName, StencilReactComponent } from '@stencil/react-output-tar
       .map((e) => `${e.name}: '${e.attribute}'`)
       .join(',\n')}},
     hydrateModule: import('${hydrateModule}') as Promise<HydrateModule>,
-    clientModule: import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>,
+    /**
+     * We need to use a dynamic import to ensure we don't load the client module
+     * during the SSR build.
+     */
+    clientModule: (() => import('./components.js') as unknown as Promise<Record<string, ReactWebComponent<any, any>>>)(),
     serializeShadowRoot,
     elementClass: ${componentElement},
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -32,6 +32,11 @@ export interface ReactOutputTargetOptions {
    */
   hydrateModule?: string;
   /**
+   * The name of the package that exports all React wrapped Stencil components for client side rendering.
+   * This options is required when `hydrateModule` is set for server side rendering to work.
+   */
+  clientModule?: string;
+  /**
    * Specify the components that should be excluded from server side rendering.
    */
   excludeServerSideRenderingFor?: string[];
@@ -85,6 +90,7 @@ export const reactOutputTarget = ({
   excludeComponents,
   customElementsDir: customElementsDirOverride,
   hydrateModule,
+  clientModule,
   excludeServerSideRenderingFor,
   serializeShadowRoot,
 }: ReactOutputTargetOptions): ReactOutputTarget => {
@@ -141,6 +147,12 @@ export const reactOutputTarget = ({
             `The '${PLUGIN_NAME}' requires '${HYDRATE_OUTPUT_TARGET}' output target when the 'hydrateModule' option is set. Add { type: '${HYDRATE_OUTPUT_TARGET}' }, to the outputTargets config.`
           );
         }
+
+        if (clientModule == null) {
+          throw new Error(
+            `The '${PLUGIN_NAME}' requires the 'clientModule' option when the 'hydrateModule' option is set. Please provide the clientModule manually to the ${PLUGIN_NAME} output target.`
+          );
+        }
       }
 
       if (!outDir) {
@@ -179,6 +191,7 @@ export const reactOutputTarget = ({
         esModules: esModules === true,
         project,
         hydrateModule,
+        clientModule,
         excludeServerSideRenderingFor,
         serializeShadowRoot,
       });

--- a/packages/react/src/runtime/ssr.tsx
+++ b/packages/react/src/runtime/ssr.tsx
@@ -1,6 +1,8 @@
 import type { EventName, Options, ReactWebComponent, WebComponentProps } from '@lit/react';
 import React, { Component, JSXElementConstructor, ReactNode } from 'react';
 import { stringifyCSSProperties } from 'react-style-stringify';
+// @ts-expect-error
+import dynamic from 'next/dynamic';
 
 import { createComponent as createComponentWrapper } from './create-component.js';
 import { possibleStandardNames } from './constants.js';
@@ -9,6 +11,8 @@ const LOG_PREFIX = '[react-output-target]';
 
 // A key value map matching React prop names to event names.
 type EventNames = Record<string, EventName | string>;
+
+export type { ReactWebComponent, WebComponentProps } from '@lit/react';
 
 export type SerializeShadowRootOptions =
   | 'declarative-shadow-dom'
@@ -61,7 +65,12 @@ export interface RenderToStringOptions {
    */
   serializeShadowRoot?: SerializeShadowRootOptions;
 }
-type RenderToString = (html: string, options: RenderToStringOptions) => Promise<{ html: string | null }>;
+interface HydrateStyle {
+  href: string | null;
+  id: string;
+  content: string;
+}
+type RenderToString = (html: string, options: RenderToStringOptions) => Promise<{ html: string | null, styles: HydrateStyle[] }>;
 
 export type HydrateModule = {
   renderToString: RenderToString;
@@ -73,7 +82,7 @@ interface CreateComponentForServerSideRenderingOptions {
   renderToString: RenderToString;
   serializeProperty: (value: any) => string;
   serializeShadowRoot?: SerializeShadowRootOptions;
-  dynamic: DynamicFunction;
+  // dynamic: DynamicFunction;
   clientModule: Promise<Record<string, ReactWebComponent<any, any>>>;
 }
 
@@ -198,9 +207,11 @@ const createComponentForServerSideRendering = <I extends HTMLElement, E extends 
       if (!process.env.STENCIL_SSR_DEBUG) {
         console.error = () => {};
       }
-      const awaitedChildren = await resolveComponentTypes(children);
-      const { renderToString } = await import('react-dom/server');
-      serializedChildren = renderToString(awaitedChildren);
+
+      // Pre-resolve all async components before rendering
+      const resolvedChildren = await resolveComponentTypes(children);
+      const ReactDOMServer = await import('react-dom/server');
+      serializedChildren = ReactDOMServer.renderToString(resolvedChildren);
     } catch (err: unknown) {
       /**
        * if rendering the light DOM fails, we log a warning and continue to render the component
@@ -209,7 +220,7 @@ const createComponentForServerSideRendering = <I extends HTMLElement, E extends 
         const error = err instanceof Error ? err : new Error('Unknown error');
         console.warn(
           `${LOG_PREFIX} Failed to serialize light DOM for ${toSerialize.slice(0, -1)} />: ${
-            error.message
+            error.stack
           } - this may impact the hydration of the component`
         );
       }
@@ -223,7 +234,7 @@ const createComponentForServerSideRendering = <I extends HTMLElement, E extends 
      * first render the component with `prettyHtml` flag so it makes it easier to
      * access the inner content of the component.
      */
-    const { html } = await options.renderToString(toSerializeWithChildren, {
+    const { html, styles } = await options.renderToString(toSerializeWithChildren, {
       fullDocument: false,
       serializeShadowRoot: options.serializeShadowRoot ?? 'declarative-shadow-dom',
       prettyHtml: true,
@@ -291,16 +302,22 @@ const createComponentForServerSideRendering = <I extends HTMLElement, E extends 
                  */
                 .replace(/(?<=>)\s+(?=<)/g, '');
 
-              return (
+              return <>
+                {styles.map((style) => (
+                  <style key={style.id} id={style.id} dangerouslySetInnerHTML={{ __html: style.content }} />
+                ))}
                 <CustomTag {...customProps} suppressHydrationWarning={true} dangerouslySetInnerHTML={{ __html }} />
-              );
+              </>;
             }
 
             /**
              * return original component with given props and `suppressHydrationWarning` flag and
              * set the template content based on our serialized Stencil component.
              */
-            return (
+            return <>
+              {styles.map((style) => (
+                <style key={style.id} id={style.id} dangerouslySetInnerHTML={{ __html: style.content }} />
+              ))}
               <CustomTag {...props} suppressHydrationWarning={true}>
                 <template
                   // @ts-expect-error
@@ -310,14 +327,14 @@ const createComponentForServerSideRendering = <I extends HTMLElement, E extends 
                 ></template>
                 {children}
               </CustomTag>
-            );
+            </>;
           }
 
           return;
         },
       });
 
-    const DynamicComponent = options.dynamic(async () => {
+    const DynamicComponent = dynamic(async () => {
       /**
        * Load client component
        */
@@ -328,7 +345,7 @@ const createComponentForServerSideRendering = <I extends HTMLElement, E extends 
         .join('')
       return () => {
         const Cmp = cmp[cmpProp]
-        return <Cmp {...props}>{children}</Cmp>
+        return <Cmp suppressHydrationWarning={true} {...props}>{children}</Cmp>
       }
     }, {
       /**
@@ -337,14 +354,14 @@ const createComponentForServerSideRendering = <I extends HTMLElement, E extends 
       loading: () => <StencilElement />,
       ssr: false,
     })
-    return <DynamicComponent />;
+    return <DynamicComponent suppressHydrationWarning={true} />;
   }) as unknown as ReactWebComponent<I, E>;
 };
 
 /**
  * Resolve the component types for server side rendering.
  *
- * It walks through all component childs and resolves them, e.g. call `createComponentForServerSideRendering` to
+ * It walks through all component children and resolves them, e.g. call `createComponentForServerSideRendering` to
  * create a React component which we can pass into `ReactDOMServer.renderToString`. This enables us to include
  * the Light DOM of a component as part of Stencils serialization process.
  *
@@ -353,15 +370,14 @@ const createComponentForServerSideRendering = <I extends HTMLElement, E extends 
  */
 async function resolveComponentTypes(children: ReactNode): Promise<ReactNode> {
   /**
-   * If the children are a empty or a primitive we can return them directly
-   * e.g. `Hello World` or `42` or `null`
+   * If the children are empty or primitive, return them directly
    */
   if (isPrimitive(children) || isEmpty(children)) {
     return children;
   }
 
   /**
-   * If the children are not iterable we make them an array, so we can map over them later
+   * If the children are not iterable, make them an array
    */
   if (!isIterable(children)) {
     children = [children];
@@ -382,59 +398,106 @@ async function resolveComponentTypes(children: ReactNode): Promise<ReactNode> {
         return child;
       }
 
-      const { type, props } = child as React.ReactElement<object & { children: ReactNode }>;
+      const { type, props } = child as React.ReactElement<any>;
 
-      return {
-        ...child,
-        props: {
-          ...props,
-          children: await resolveComponentTypes(props.children),
-        },
-        type: await resolveType(type, props as any),
-      } as ReactNode;
+      try {
+        const resolvedType = await resolveType(type, props);
+
+        /**
+         * If the resolved type is a ReactElement, return it directly
+         */
+        if (React.isValidElement(resolvedType)) {
+          return resolvedType;
+        }
+
+        const resolvedChildren = props?.children ? await resolveComponentTypes(props.children) : props?.children;
+
+        /**
+         * If the resolved type is a string (HTML element), create a new element
+         */
+        if (typeof resolvedType === 'string') {
+          return React.createElement(resolvedType, { ...props, children: resolvedChildren });
+        }
+
+        /**
+         * Otherwise, return the original child with resolved children
+         */
+        return React.cloneElement(child, { ...props, children: resolvedChildren });
+      } catch (error) {
+        if (process.env.STENCIL_SSR_DEBUG) {
+          console.warn('Failed to resolve component type:', error);
+        }
+        return child;
+      }
     })
   );
 }
 
 // Resolve the component type to a primitive element type
 const resolveType = async (type: string | React.JSXElementConstructor<any>, props: any): Promise<ReactNodeExtended> => {
-  let resolvedType: ReactNodeExtended = null;
-
+  /**
+   * Child is a primitive element like 'div'
+   */
   if (typeof type === 'string') {
-    // Child is a primitive element like 'div'
     return type;
-  } else if (isJSXClassElementConstructor(type)) {
-    // Child is a Class Component
-    const instance = new type(props);
-    resolvedType = instance.render ? instance.render() : instance;
-  } else if (isLazyExoticComponent(type)) {
-    // Handle React Lazy Component
-    // https://github.com/facebook/react/blob/main/packages/react/src/ReactLazy.js
-    const payload = type._payload;
-    const { deault: lazyComponet } =
-      payload._status === -1 // Uninitialized = -1 so we need resolve the promise
+  }
+
+  try {
+    let resolvedType: ReactNodeExtended = null;
+
+    if (isJSXClassElementConstructor(type)) {
+      /**
+       * Child is a Class Component
+       */
+      const instance = new type(props);
+      resolvedType = instance.render ? await instance.render() : instance;
+    } else if (isLazyExoticComponent(type)) {
+      /**
+       * Handle React Lazy Component
+       */
+      const payload = type._payload;
+      const lazyResult = payload._status === -1 // Uninitialized = -1 so we need to resolve the promise
         ? await payload._result()
         : payload._result;
-    // Now resolve the actual component type of the lazy component
-    resolvedType = await resolveType(lazyComponet, props);
-  } else if (typeof type !== 'object') {
-    // Child is a Function Component because React Server
-    // Components can be a Promise we need to await it
-    resolvedType = await type(props);
-  }
 
-  // Recursively resolve the component type until we have a primitive element type
-  if (
-    !isEmpty(resolvedType) &&
-    !isPrimitive(resolvedType) &&
-    typeof resolvedType === 'object' &&
-    resolvedType !== null &&
-    'type' in resolvedType
-  ) {
-    resolvedType = await resolveType(resolvedType.type, props);
-  }
+      const lazyComponent = lazyResult.default || lazyResult;
+      resolvedType = await resolveType(lazyComponent, props);
+    } else if (typeof type === 'function') {
+      /**
+       * Child is a Function Component (including async Server Components)
+       */
+      let result: any = type(props);
 
-  return resolvedType;
+      /**
+       * If the result is a Promise, await it
+       */
+      if (result && typeof result === 'object' && 'then' in result && typeof result.then === 'function') {
+        result = await result;
+      }
+
+      resolvedType = result as ReactNodeExtended;
+    }
+
+    /**
+     * Recursively resolve nested component types
+     */
+    while (
+      resolvedType &&
+      typeof resolvedType === 'object' &&
+      !React.isValidElement(resolvedType) &&
+      !isPrimitive(resolvedType) &&
+      'type' in resolvedType
+    ) {
+      resolvedType = await resolveType((resolvedType as any).type, props);
+    }
+
+    return resolvedType;
+  } catch (error) {
+    if (process.env.STENCIL_SSR_DEBUG) {
+      console.warn('Error resolving component type:', error);
+    }
+    return null;
+  }
 };
 
 /**
@@ -453,7 +516,7 @@ export const createComponent = <I extends HTMLElement, E extends EventNames = {}
   tagName: string;
   serializeShadowRoot?: SerializeShadowRootOptions;
   clientModule: Promise<Record<string, ReactWebComponent<any, any>>>;
-} & Options<I, E> & { defineCustomElement: () => void, dynamic: DynamicFunction }): ReactWebComponent<I, E> => {
+} & Options<I, E> & { defineCustomElement: () => void }): ReactWebComponent<I, E> => {
   /**
    * If we are running in the browser, we can use the `createComponentWrapper` function
    * to create a React component that can be used in the browser. This allows to import

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['@stencil/core', '@lit/react', 'typescript', 'react', 'react-dom/server', 'ts-morph', 'html-react-parser', 'node:path'],
+      external: [
+        '@stencil/core', '@lit/react', 'typescript', 'react',
+        'react-dom/server', 'ts-morph', 'html-react-parser',
+        'node:path', 'next/dynamic'
+      ],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,21 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
 
+  example-project/component-library-angular/projects/library/dist:
+    dependencies:
+      '@angular/common':
+        specifier: ^20.0.0
+        version: 20.0.3(@angular/core@20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core':
+        specifier: ^20.0.0
+        version: 20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1)
+      component-library:
+        specifier: workspace:*
+        version: link:../../../../component-library
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
   example-project/component-library-react:
     dependencies:
       '@stencil/react-output-target':
@@ -150,9 +165,6 @@ importers:
       component-library:
         specifier: workspace:*
         version: link:../component-library
-      next:
-        specifier: ^15.1.6
-        version: 15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.2)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -215,6 +227,8 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.15.31)(jsdom@20.0.3)(less@4.3.0)(sass@1.89.2)(terser@5.42.0)
+
+  example-project/component-library/hydrate: {}
 
   example-project/next-15-react-19-app:
     dependencies:
@@ -23261,32 +23275,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.2):
-    dependencies:
-      '@next/env': 15.3.3
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.15
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001723
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.3.3
-      '@next/swc-darwin-x64': 15.3.3
-      '@next/swc-linux-arm64-gnu': 15.3.3
-      '@next/swc-linux-arm64-musl': 15.3.3
-      '@next/swc-linux-x64-gnu': 15.3.3
-      '@next/swc-linux-x64-musl': 15.3.3
-      '@next/swc-win32-arm64-msvc': 15.3.3
-      '@next/swc-win32-x64-msvc': 15.3.3
-      sass: 1.89.2
-      sharp: 0.34.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2):
     dependencies:
       '@next/env': 15.3.3
@@ -26125,11 +26113,6 @@ snapshots:
       inline-style-parser: 0.2.4
 
   styled-jsx@5.1.1(react@18.3.1):
-    dependencies:
-      client-only: 0.0.1
-      react: 18.3.1
-
-  styled-jsx@5.1.6(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ^20.0.2
-        version: 20.0.2(vcsrxpmqoebxlfzo7uvapij56i)
+        version: 20.0.2(edf2cf0bfa72d016d05ab4537b0a9808)
       '@angular/cli':
         specifier: ^20.0.2
         version: 20.0.2(@types/node@22.15.31)(chokidar@4.0.3)
@@ -113,7 +113,7 @@ importers:
         version: 29.7.0
       jest-preset-angular:
         specifier: ^14.6.0
-        version: 14.6.0(dtijvbxsrnbgpbzaolcvbeo6e4)
+        version: 14.6.0(e7bd9f095dc3de8b8518dc74098790e4)
       ng-packagr:
         specifier: ^20.0.0
         version: 20.0.0(@angular/compiler-cli@20.0.3(@angular/compiler@20.0.3)(typescript@5.8.3))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.31)(typescript@5.8.3)))(tslib@2.8.1)(typescript@5.8.3)
@@ -165,6 +165,9 @@ importers:
       component-library:
         specifier: workspace:*
         version: link:../component-library
+      next:
+        specifier: ^15.1.6
+        version: 15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.2)
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -511,7 +514,7 @@ importers:
     devDependencies:
       '@angular/build':
         specifier: ^20.0.2
-        version: 20.0.2(qn6na3wfbjhhpdpndlcepe2sa4)
+        version: 20.0.2(080eb11d1c38540c2d8467faa49d7a46)
       '@angular/cli':
         specifier: ^20.0.2
         version: 20.0.2(@types/node@22.15.31)(chokidar@4.0.3)
@@ -13024,7 +13027,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@angular/build@20.0.2(qn6na3wfbjhhpdpndlcepe2sa4)':
+  '@angular/build@20.0.2(080eb11d1c38540c2d8467faa49d7a46)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.2(chokidar@4.0.3)
@@ -13078,7 +13081,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@20.0.2(vcsrxpmqoebxlfzo7uvapij56i)':
+  '@angular/build@20.0.2(edf2cf0bfa72d016d05ab4537b0a9808)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2000.2(chokidar@4.0.3)
@@ -21676,7 +21679,7 @@ snapshots:
     optionalDependencies:
       jest-resolve: 29.7.0
 
-  jest-preset-angular@14.6.0(dtijvbxsrnbgpbzaolcvbeo6e4):
+  jest-preset-angular@14.6.0(e7bd9f095dc3de8b8518dc74098790e4):
     dependencies:
       '@angular/compiler-cli': 20.0.3(@angular/compiler@20.0.3)(typescript@5.8.3)
       '@angular/core': 20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1)
@@ -23271,6 +23274,32 @@ snapshots:
       '@next/swc-win32-x64-msvc': 15.2.3
       sass: 1.89.2
       sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@15.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.2):
+    dependencies:
+      '@next/env': 15.3.3
+      '@swc/counter': 0.1.3
+      '@swc/helpers': 0.5.15
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001723
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.6(react@18.3.1)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.3.3
+      '@next/swc-darwin-x64': 15.3.3
+      '@next/swc-linux-arm64-gnu': 15.3.3
+      '@next/swc-linux-arm64-musl': 15.3.3
+      '@next/swc-linux-x64-gnu': 15.3.3
+      '@next/swc-linux-x64-musl': 15.3.3
+      '@next/swc-win32-arm64-msvc': 15.3.3
+      '@next/swc-win32-x64-msvc': 15.3.3
+      sass: 1.89.2
+      sharp: 0.34.2
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -26113,6 +26142,11 @@ snapshots:
       inline-style-parser: 0.2.4
 
   styled-jsx@5.1.1(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+
+  styled-jsx@5.1.6(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,21 +142,6 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
 
-  example-project/component-library-angular/projects/library/dist:
-    dependencies:
-      '@angular/common':
-        specifier: ^20.0.0
-        version: 20.0.3(@angular/core@20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core':
-        specifier: ^20.0.0
-        version: 20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1)
-      component-library:
-        specifier: workspace:*
-        version: link:../../../../component-library
-      tslib:
-        specifier: ^2.3.0
-        version: 2.8.1
-
   example-project/component-library-react:
     dependencies:
       '@stencil/react-output-target':
@@ -230,8 +215,6 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.15.31)(jsdom@20.0.3)(less@4.3.0)(sass@1.89.2)(terser@5.42.0)
-
-  example-project/component-library/hydrate: {}
 
   example-project/next-15-react-19-app:
     dependencies:

--- a/tests/react/tests/helpers.ts
+++ b/tests/react/tests/helpers.ts
@@ -95,7 +95,8 @@ export function assertClientSideErrors () {
       !error.includes('hydrating') &&
       !error.includes('Expected server HTML to contain a matching') &&
       !error.includes('Did not expect server HTML to contain') &&
-      !error.includes('error node')
+      !error.includes('error node') &&
+      !error.includes('failed to connect to websocket')
     ))
     if (nonHydrationErrors.length > 0) {
       throw new Error(`Errors were logged during the tests:\n  - ${nonHydrationErrors.join('\n  - ')}`)

--- a/tests/react/tests/helpers.ts
+++ b/tests/react/tests/helpers.ts
@@ -96,7 +96,11 @@ export function assertClientSideErrors () {
       !error.includes('Expected server HTML to contain a matching') &&
       !error.includes('Did not expect server HTML to contain') &&
       !error.includes('error node') &&
-      !error.includes('failed to connect to websocket')
+      /**
+       * WebdriverIO related socket errors that only appeared in CI on MacOS
+       */
+      !error.includes('failed to connect to websocket') &&
+      !error.includes('WebSocket closed without opened.')
     ))
     if (nonHydrationErrors.length > 0) {
       throw new Error(`Errors were logged during the tests:\n  - ${nonHydrationErrors.join('\n  - ')}`)

--- a/tests/react/tests/scenarios.ts
+++ b/tests/react/tests/scenarios.ts
@@ -11,11 +11,25 @@ const testScenarios: Record<TestComponent, () => void> = {
 }
 
 interface TestScenarioOptions {
+  /**
+   * If provided, the test will only run the scenarios that are in the array
+   * @default []
+   */
   only?: TestComponent[]
+  /**
+   * If provided, the test will skip the scenarios that are in the array
+   * @default []
+   */
   exclude?: TestComponent[]
+  /**
+   * If true, the test will assert that no client side errors
+   * e.g. hydration errors were logged
+   * @default true
+   */
+  assertClientSideErrors?: boolean
 }
 
-export const runTestScenarios = ({ only, exclude }: TestScenarioOptions = {}) => {
+export const runTestScenarios = ({ only, exclude, ...opts }: TestScenarioOptions = {}) => {
   const scenarions = (Object.entries(testScenarios) as [TestComponent, () => void][])
     .filter(([key]) => !only || only.includes(key))
     .filter(([key]) => !exclude || !exclude.includes(key))
@@ -24,7 +38,9 @@ export const runTestScenarios = ({ only, exclude }: TestScenarioOptions = {}) =>
    * track all errors that are logged during the tests and assert
    * that no errors were logged
    */
-  assertClientSideErrors()
+  if (typeof opts.assertClientSideErrors !== 'boolean' || opts.assertClientSideErrors) {
+    assertClientSideErrors()
+  }
 
   scenarions.forEach(([name, test]) => {
     describe(name, test)

--- a/tests/react/tests/scenarios/scoped.ts
+++ b/tests/react/tests/scenarios/scoped.ts
@@ -19,6 +19,7 @@ export const testScenarios: Record<ScopedComponents, () => void | undefined> = {
     it('should have correctly hydrated component', async () => {
       await browser.url('/single-no-child-scoped')
       await expect($('my-component-scoped')).toBePresent()
+      await expect($('my-component-scoped').$('div')).toBePresent()
       await expect($('my-component-scoped').$('div')).toHaveText('Hello, World! I\'m John William Doe')
     })
 


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Currently, server-side rendered React components using Stencil only render the Declarative Shadow DOM (DSD) version on the server. There's no mechanism to dynamically load and hydrate with the actual client-side React component after initial rendering.

Issue URL: [Please provide issue URL]

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added support for dynamic SSR with client-side hydration using a Next.js-like dynamic import pattern
- Introduced new TypeScript types (`DynamicImport`, `DynamicOptions`, `DynamicFunction`) to support dynamic loading without requiring Next.js dependencies
- Enhanced `CreateComponentForServerSideRenderingOptions` to accept `dynamic` function and `clientModule` promise
- Modified server-side rendering to wrap components with a dynamic loader that:
  - Initially renders the Declarative Shadow DOM version (for SSR)
  - Dynamically loads and switches to the client-side component after hydration
  - Supports loading states and SSR configuration options

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

This is an additive feature that extends the existing SSR functionality. Existing code will continue to work as before, but now developers can opt into dynamic SSR behavior by providing the new `dynamic` and `clientModule` options.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This enhancement enables a hybrid SSR approach where:
1. The server renders Declarative Shadow DOM for initial paint and SEO
2. The client dynamically loads the full React component for interactivity
3. The transition is seamless with configurable loading states

This pattern is particularly useful for complex components that need both server-side rendering benefits and full client-side functionality, similar to Next.js dynamic imports but adapted for Stencil components.