### PR TITLE
fix(angular): use forwardRef in control value accessor directives.

### DIFF
--- a/example-project/component-library-angular/projects/library/src/directives/boolean-value-accessor.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/boolean-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -12,7 +12,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: BooleanValueAccessor,
+      useExisting: forwardRef(() => BooleanValueAccessor),
       multi: true
     }
   ]

--- a/example-project/component-library-angular/projects/library/src/directives/number-value-accessor.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/number-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -12,7 +12,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: NumericValueAccessor,
+      useExisting: forwardRef(() => NumericValueAccessor),
       multi: true
     }
   ]

--- a/example-project/component-library-angular/projects/library/src/directives/radio-value-accessor.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/radio-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -12,7 +12,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: RadioValueAccessor,
+      useExisting: forwardRef(() => RadioValueAccessor),
       multi: true
     }
   ]

--- a/example-project/component-library-angular/projects/library/src/directives/select-value-accessor.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/select-value-accessor.ts
@@ -1,7 +1,8 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
+import { userInfo } from 'os';
 
 @Directive({
   /* tslint:disable-next-line:directive-selector */
@@ -12,7 +13,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: SelectValueAccessor,
+      useExisting: forwardRef(() => SelectValueAccessor),
       multi: true
     }
   ]

--- a/example-project/component-library-angular/projects/library/src/directives/text-value-accessor.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/text-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -12,7 +12,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: TextValueAccessor,
+      useExisting: forwardRef(() => TextValueAccessor),
       multi: true
     }
   ]

--- a/packages/angular/resources/control-value-accessors/boolean-value-accessor.ts
+++ b/packages/angular/resources/control-value-accessors/boolean-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -12,7 +12,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: BooleanValueAccessor,
+      useExisting: forwardRef(() => BooleanValueAccessor),
       multi: true
     }
   ]<VALUE_ACCESSOR_STANDALONE>

--- a/packages/angular/resources/control-value-accessors/number-value-accessor.ts
+++ b/packages/angular/resources/control-value-accessors/number-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -12,7 +12,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: NumericValueAccessor,
+      useExisting: forwardRef(() => NumericValueAccessor),
       multi: true
     }
   ]<VALUE_ACCESSOR_STANDALONE>

--- a/packages/angular/resources/control-value-accessors/radio-value-accessor.ts
+++ b/packages/angular/resources/control-value-accessors/radio-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -12,7 +12,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: RadioValueAccessor,
+      useExisting: forwardRef(() => RadioValueAccessor),
       multi: true
     }
   ]<VALUE_ACCESSOR_STANDALONE>

--- a/packages/angular/resources/control-value-accessors/select-value-accessor.ts
+++ b/packages/angular/resources/control-value-accessors/select-value-accessor.ts
@@ -1,7 +1,8 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
+import { userInfo } from 'os';
 
 @Directive({
   /* tslint:disable-next-line:directive-selector */
@@ -12,7 +13,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: SelectValueAccessor,
+      useExisting: forwardRef(() => SelectValueAccessor),
       multi: true
     }
   ]<VALUE_ACCESSOR_STANDALONE>

--- a/packages/angular/resources/control-value-accessors/text-value-accessor.ts
+++ b/packages/angular/resources/control-value-accessors/text-value-accessor.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef } from '@angular/core';
+import { Directive, ElementRef, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ValueAccessor } from './value-accessor';
@@ -12,7 +12,7 @@ import { ValueAccessor } from './value-accessor';
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
-      useExisting: TextValueAccessor,
+      useExisting: forwardRef(() => TextValueAccessor),
       multi: true
     }
   ]<VALUE_ACCESSOR_STANDALONE>

--- a/packages/angular/tests/generate-value-accessors.test.ts
+++ b/packages/angular/tests/generate-value-accessors.test.ts
@@ -17,7 +17,7 @@ describe('createValueAccessor', () => {
     const srcFile = fs.readFileSync(srcFilePath, { encoding: 'utf-8' });
     const finalText = createValueAccessor(srcFile, valueAccessor, 'component');
     expect(finalText.trim()).toMatchInlineSnapshot(`
-      "import { Directive, ElementRef } from '@angular/core';
+      "import { Directive, ElementRef, forwardRef } from '@angular/core';
       import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
       import { ValueAccessor } from './value-accessor';
@@ -32,7 +32,7 @@ describe('createValueAccessor', () => {
         providers: [
           {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: TextValueAccessor,
+            useExisting: forwardRef(() => TextValueAccessor),
             multi: true
           }
         ],
@@ -58,7 +58,7 @@ describe('createValueAccessor', () => {
     const srcFile = fs.readFileSync(srcFilePath, { encoding: 'utf-8' });
     const finalText = createValueAccessor(srcFile, valueAccessor, 'standalone');
     expect(finalText.trim()).toMatchInlineSnapshot(`
-      "import { Directive, ElementRef } from '@angular/core';
+      "import { Directive, ElementRef, forwardRef } from '@angular/core';
       import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
       import { ValueAccessor } from './value-accessor';
@@ -73,7 +73,7 @@ describe('createValueAccessor', () => {
         providers: [
           {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: TextValueAccessor,
+            useExisting: forwardRef(() => TextValueAccessor),
             multi: true
           }
         ]


### PR DESCRIPTION
- This avoids "Class used before its declaration" error.

## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL: https://github.com/stenciljs/output-targets/issues/696

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- ControlValueAccessor will now be generated with forwardRef in use

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
