### PR TITLE
fix(react): revert 1.5.1 (reflect required props in component type when used in TSX)

### DIFF
--- a/example-project/component-library-angular/projects/library/src/directives/proxies.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/proxies.ts
@@ -204,7 +204,7 @@ export declare interface MyComplexPropsScoped extends Components.MyComplexPropsS
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: [{ name: 'first', required: true }, 'last', 'middleName'],
+  inputs: ['first', 'last', 'middleName'],
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;

--- a/example-project/component-library-react/src/components.server.ts
+++ b/example-project/component-library-react/src/components.server.ts
@@ -15,7 +15,7 @@ import { createComponent, type HydrateModule, type SerializeShadowRootOptions } 
 import { type CheckboxChangeEventDetail, type CheckboxChangeNestedEventDetail, type IMyComponent, type InputChangeEventDetail, type MyButtonCustomEvent, type MyButtonScopedCustomEvent, type MyCheckboxCustomEvent, type MyComponentScopedCustomEvent, type MyCounterCustomEvent, type MyInputCustomEvent, type MyInputScopedCustomEvent, type MyPopoverCustomEvent, type MyRadioCustomEvent, type MyRadioGroupCustomEvent, type MyRangeCustomEvent, type OverlayEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail } from "component-library";
 // @ts-ignore - ignore potential type issues as the project is importing itself
 import * as clientComponents from "component-library-react";
-import type { JSX } from "component-library/components";
+import type { Components } from "component-library/components";
 import { MyButtonScoped as MyButtonScopedElement } from "component-library/components/my-button-scoped.js";
 import { MyButton as MyButtonElement } from "component-library/components/my-button.js";
 import { MyCheckbox as MyCheckboxElement } from "component-library/components/my-checkbox.js";
@@ -46,7 +46,7 @@ export type MyButtonEvents = {
     onMyBlur: EventName<MyButtonCustomEvent<void>>
 };
 
-export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents, JSX.MyButton> = /*@__PURE__*/ createComponent<MyButtonElement, MyButtonEvents, JSX.MyButton>({
+export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents, Components.MyButton> = /*@__PURE__*/ createComponent<MyButtonElement, MyButtonEvents, Components.MyButton>({
     tagName: 'my-button',
     properties: {
         color: 'color',
@@ -64,7 +64,7 @@ export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents, JS
         type: 'type'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyButton as StencilReactComponent<MyButtonElement, MyButtonEvents, JSX.MyButton>,
+    clientModule: clientComponents.MyButton as StencilReactComponent<MyButtonElement, MyButtonEvents, Components.MyButton>,
     serializeShadowRoot,
     getTagTransformer
 });
@@ -74,7 +74,7 @@ export type MyButtonScopedEvents = {
     onMyBlur: EventName<MyButtonScopedCustomEvent<void>>
 };
 
-export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButtonScopedEvents, JSX.MyButtonScoped> = /*@__PURE__*/ createComponent<MyButtonScopedElement, MyButtonScopedEvents, JSX.MyButtonScoped>({
+export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButtonScopedEvents, Components.MyButtonScoped> = /*@__PURE__*/ createComponent<MyButtonScopedElement, MyButtonScopedEvents, Components.MyButtonScoped>({
     tagName: 'my-button-scoped',
     properties: {
         color: 'color',
@@ -92,7 +92,7 @@ export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButt
         type: 'type'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyButtonScoped as StencilReactComponent<MyButtonScopedElement, MyButtonScopedEvents, JSX.MyButtonScoped>,
+    clientModule: clientComponents.MyButtonScoped as StencilReactComponent<MyButtonScopedElement, MyButtonScopedEvents, Components.MyButtonScoped>,
     serializeShadowRoot,
     getTagTransformer
 });
@@ -104,7 +104,7 @@ export type MyCheckboxEvents = {
     onIonBlur: EventName<MyCheckboxCustomEvent<void>>
 };
 
-export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEvents, JSX.MyCheckbox> = /*@__PURE__*/ createComponent<MyCheckboxElement, MyCheckboxEvents, JSX.MyCheckbox>({
+export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEvents, Components.MyCheckbox> = /*@__PURE__*/ createComponent<MyCheckboxElement, MyCheckboxEvents, Components.MyCheckbox>({
     tagName: 'my-checkbox',
     properties: {
         color: 'color',
@@ -118,36 +118,36 @@ export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEven
         alignment: 'alignment'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyCheckbox as StencilReactComponent<MyCheckboxElement, MyCheckboxEvents, JSX.MyCheckbox>,
+    clientModule: clientComponents.MyCheckbox as StencilReactComponent<MyCheckboxElement, MyCheckboxEvents, Components.MyCheckbox>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyComplexPropsEvents = NonNullable<unknown>;
 
-export const MyComplexProps: StencilReactComponent<MyComplexPropsElement, MyComplexPropsEvents, JSX.MyComplexProps> = /*@__PURE__*/ createComponent<MyComplexPropsElement, MyComplexPropsEvents, JSX.MyComplexProps>({
+export const MyComplexProps: StencilReactComponent<MyComplexPropsElement, MyComplexPropsEvents, Components.MyComplexProps> = /*@__PURE__*/ createComponent<MyComplexPropsElement, MyComplexPropsEvents, Components.MyComplexProps>({
     tagName: 'my-complex-props',
     properties: { grault: 'grault' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyComplexProps as StencilReactComponent<MyComplexPropsElement, MyComplexPropsEvents, JSX.MyComplexProps>,
+    clientModule: clientComponents.MyComplexProps as StencilReactComponent<MyComplexPropsElement, MyComplexPropsEvents, Components.MyComplexProps>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyComplexPropsScopedEvents = NonNullable<unknown>;
 
-export const MyComplexPropsScoped: StencilReactComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, JSX.MyComplexPropsScoped> = /*@__PURE__*/ createComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, JSX.MyComplexPropsScoped>({
+export const MyComplexPropsScoped: StencilReactComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, Components.MyComplexPropsScoped> = /*@__PURE__*/ createComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, Components.MyComplexPropsScoped>({
     tagName: 'my-complex-props-scoped',
     properties: { grault: 'grault' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyComplexPropsScoped as StencilReactComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, JSX.MyComplexPropsScoped>,
+    clientModule: clientComponents.MyComplexPropsScoped as StencilReactComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, Components.MyComplexPropsScoped>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyComponentEvents = NonNullable<unknown>;
 
-export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>({
+export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>({
     tagName: 'my-component',
     properties: {
         first: 'first',
@@ -155,25 +155,25 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
         last: 'last'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyComponent as StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>,
+    clientModule: clientComponents.MyComponent as StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyComponentDelegatesFocusEvents = NonNullable<unknown>;
 
-export const MyComponentDelegatesFocus: StencilReactComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, JSX.MyComponentDelegatesFocus> = /*@__PURE__*/ createComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, JSX.MyComponentDelegatesFocus>({
+export const MyComponentDelegatesFocus: StencilReactComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, Components.MyComponentDelegatesFocus> = /*@__PURE__*/ createComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, Components.MyComponentDelegatesFocus>({
     tagName: 'my-component-delegates-focus',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyComponentDelegatesFocus as StencilReactComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, JSX.MyComponentDelegatesFocus>,
+    clientModule: clientComponents.MyComponentDelegatesFocus as StencilReactComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, Components.MyComponentDelegatesFocus>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyComponentScopedEvents = { onMyCustomEvent: EventName<MyComponentScopedCustomEvent<IMyComponent.someVar>> };
 
-export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, MyComponentScopedEvents, JSX.MyComponentScoped> = /*@__PURE__*/ createComponent<MyComponentScopedElement, MyComponentScopedEvents, JSX.MyComponentScoped>({
+export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, MyComponentScopedEvents, Components.MyComponentScoped> = /*@__PURE__*/ createComponent<MyComponentScopedElement, MyComponentScopedEvents, Components.MyComponentScoped>({
     tagName: 'my-component-scoped',
     properties: {
         first: 'first',
@@ -181,18 +181,18 @@ export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, 
         last: 'last'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyComponentScoped as StencilReactComponent<MyComponentScopedElement, MyComponentScopedEvents, JSX.MyComponentScoped>,
+    clientModule: clientComponents.MyComponentScoped as StencilReactComponent<MyComponentScopedElement, MyComponentScopedEvents, Components.MyComponentScoped>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyCounterEvents = { onCount: EventName<MyCounterCustomEvent<number>> };
 
-export const MyCounter: StencilReactComponent<MyCounterElement, MyCounterEvents, JSX.MyCounter> = /*@__PURE__*/ createComponent<MyCounterElement, MyCounterEvents, JSX.MyCounter>({
+export const MyCounter: StencilReactComponent<MyCounterElement, MyCounterEvents, Components.MyCounter> = /*@__PURE__*/ createComponent<MyCounterElement, MyCounterEvents, Components.MyCounter>({
     tagName: 'my-counter',
     properties: { startValue: 'start-value' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyCounter as StencilReactComponent<MyCounterElement, MyCounterEvents, JSX.MyCounter>,
+    clientModule: clientComponents.MyCounter as StencilReactComponent<MyCounterElement, MyCounterEvents, Components.MyCounter>,
     serializeShadowRoot,
     getTagTransformer
 });
@@ -204,7 +204,7 @@ export type MyInputEvents = {
     onMyFocus: EventName<MyInputCustomEvent<void>>
 };
 
-export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents, JSX.MyInput> = /*@__PURE__*/ createComponent<MyInputElement, MyInputEvents, JSX.MyInput>({
+export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents, Components.MyInput> = /*@__PURE__*/ createComponent<MyInputElement, MyInputEvents, Components.MyInput>({
     tagName: 'my-input',
     properties: {
         color: 'color',
@@ -235,7 +235,7 @@ export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents, JSX.M
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyInput as StencilReactComponent<MyInputElement, MyInputEvents, JSX.MyInput>,
+    clientModule: clientComponents.MyInput as StencilReactComponent<MyInputElement, MyInputEvents, Components.MyInput>,
     serializeShadowRoot,
     getTagTransformer
 });
@@ -247,7 +247,7 @@ export type MyInputScopedEvents = {
     onMyFocus: EventName<MyInputScopedCustomEvent<void>>
 };
 
-export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputScopedEvents, JSX.MyInputScoped> = /*@__PURE__*/ createComponent<MyInputScopedElement, MyInputScopedEvents, JSX.MyInputScoped>({
+export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputScopedEvents, Components.MyInputScoped> = /*@__PURE__*/ createComponent<MyInputScopedElement, MyInputScopedEvents, Components.MyInputScoped>({
     tagName: 'my-input-scoped',
     properties: {
         color: 'color',
@@ -278,51 +278,51 @@ export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputS
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyInputScoped as StencilReactComponent<MyInputScopedElement, MyInputScopedEvents, JSX.MyInputScoped>,
+    clientModule: clientComponents.MyInputScoped as StencilReactComponent<MyInputScopedElement, MyInputScopedEvents, Components.MyInputScoped>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyListEvents = NonNullable<unknown>;
 
-export const MyList: StencilReactComponent<MyListElement, MyListEvents, JSX.MyList> = /*@__PURE__*/ createComponent<MyListElement, MyListEvents, JSX.MyList>({
+export const MyList: StencilReactComponent<MyListElement, MyListEvents, Components.MyList> = /*@__PURE__*/ createComponent<MyListElement, MyListEvents, Components.MyList>({
     tagName: 'my-list',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyList as StencilReactComponent<MyListElement, MyListEvents, JSX.MyList>,
+    clientModule: clientComponents.MyList as StencilReactComponent<MyListElement, MyListEvents, Components.MyList>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyListItemEvents = NonNullable<unknown>;
 
-export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEvents, JSX.MyListItem> = /*@__PURE__*/ createComponent<MyListItemElement, MyListItemEvents, JSX.MyListItem>({
+export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEvents, Components.MyListItem> = /*@__PURE__*/ createComponent<MyListItemElement, MyListItemEvents, Components.MyListItem>({
     tagName: 'my-list-item',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyListItem as StencilReactComponent<MyListItemElement, MyListItemEvents, JSX.MyListItem>,
+    clientModule: clientComponents.MyListItem as StencilReactComponent<MyListItemElement, MyListItemEvents, Components.MyListItem>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyListItemScopedEvents = NonNullable<unknown>;
 
-export const MyListItemScoped: StencilReactComponent<MyListItemScopedElement, MyListItemScopedEvents, JSX.MyListItemScoped> = /*@__PURE__*/ createComponent<MyListItemScopedElement, MyListItemScopedEvents, JSX.MyListItemScoped>({
+export const MyListItemScoped: StencilReactComponent<MyListItemScopedElement, MyListItemScopedEvents, Components.MyListItemScoped> = /*@__PURE__*/ createComponent<MyListItemScopedElement, MyListItemScopedEvents, Components.MyListItemScoped>({
     tagName: 'my-list-item-scoped',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyListItemScoped as StencilReactComponent<MyListItemScopedElement, MyListItemScopedEvents, JSX.MyListItemScoped>,
+    clientModule: clientComponents.MyListItemScoped as StencilReactComponent<MyListItemScopedElement, MyListItemScopedEvents, Components.MyListItemScoped>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyListScopedEvents = NonNullable<unknown>;
 
-export const MyListScoped: StencilReactComponent<MyListScopedElement, MyListScopedEvents, JSX.MyListScoped> = /*@__PURE__*/ createComponent<MyListScopedElement, MyListScopedEvents, JSX.MyListScoped>({
+export const MyListScoped: StencilReactComponent<MyListScopedElement, MyListScopedEvents, Components.MyListScoped> = /*@__PURE__*/ createComponent<MyListScopedElement, MyListScopedEvents, Components.MyListScoped>({
     tagName: 'my-list-scoped',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyListScoped as StencilReactComponent<MyListScopedElement, MyListScopedEvents, JSX.MyListScoped>,
+    clientModule: clientComponents.MyListScoped as StencilReactComponent<MyListScopedElement, MyListScopedEvents, Components.MyListScoped>,
     serializeShadowRoot,
     getTagTransformer
 });
@@ -334,7 +334,7 @@ export type MyPopoverEvents = {
     onMyPopoverDidDismiss: EventName<MyPopoverCustomEvent<OverlayEventDetail>>
 };
 
-export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents, JSX.MyPopover> = /*@__PURE__*/ createComponent<MyPopoverElement, MyPopoverEvents, JSX.MyPopover>({
+export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents, Components.MyPopover> = /*@__PURE__*/ createComponent<MyPopoverElement, MyPopoverEvents, Components.MyPopover>({
     tagName: 'my-popover',
     properties: {
         component: 'component',
@@ -347,7 +347,7 @@ export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents,
         animated: 'animated'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyPopover as StencilReactComponent<MyPopoverElement, MyPopoverEvents, JSX.MyPopover>,
+    clientModule: clientComponents.MyPopover as StencilReactComponent<MyPopoverElement, MyPopoverEvents, Components.MyPopover>,
     serializeShadowRoot,
     getTagTransformer
 });
@@ -357,7 +357,7 @@ export type MyRadioEvents = {
     onIonBlur: EventName<MyRadioCustomEvent<void>>
 };
 
-export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents, JSX.MyRadio> = /*@__PURE__*/ createComponent<MyRadioElement, MyRadioEvents, JSX.MyRadio>({
+export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents, Components.MyRadio> = /*@__PURE__*/ createComponent<MyRadioElement, MyRadioEvents, Components.MyRadio>({
     tagName: 'my-radio',
     properties: {
         color: 'color',
@@ -369,14 +369,14 @@ export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents, JSX.M
         alignment: 'alignment'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyRadio as StencilReactComponent<MyRadioElement, MyRadioEvents, JSX.MyRadio>,
+    clientModule: clientComponents.MyRadio as StencilReactComponent<MyRadioElement, MyRadioEvents, Components.MyRadio>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyRadioGroupEvents = { onMyChange: EventName<MyRadioGroupCustomEvent<RadioGroupChangeEventDetail>> };
 
-export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGroupEvents, JSX.MyRadioGroup> = /*@__PURE__*/ createComponent<MyRadioGroupElement, MyRadioGroupEvents, JSX.MyRadioGroup>({
+export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGroupEvents, Components.MyRadioGroup> = /*@__PURE__*/ createComponent<MyRadioGroupElement, MyRadioGroupEvents, Components.MyRadioGroup>({
     tagName: 'my-radio-group',
     properties: {
         allowEmptySelection: 'allow-empty-selection',
@@ -385,7 +385,7 @@ export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGro
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyRadioGroup as StencilReactComponent<MyRadioGroupElement, MyRadioGroupEvents, JSX.MyRadioGroup>,
+    clientModule: clientComponents.MyRadioGroup as StencilReactComponent<MyRadioGroupElement, MyRadioGroupEvents, Components.MyRadioGroup>,
     serializeShadowRoot,
     getTagTransformer
 });
@@ -396,7 +396,7 @@ export type MyRangeEvents = {
     onMyBlur: EventName<MyRangeCustomEvent<void>>
 };
 
-export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents, JSX.MyRange> = /*@__PURE__*/ createComponent<MyRangeElement, MyRangeEvents, JSX.MyRange>({
+export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents, Components.MyRange> = /*@__PURE__*/ createComponent<MyRangeElement, MyRangeEvents, Components.MyRange>({
     tagName: 'my-range',
     properties: {
         color: 'color',
@@ -413,40 +413,40 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents, JSX.M
         value: 'value'
     },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyRange as StencilReactComponent<MyRangeElement, MyRangeEvents, JSX.MyRange>,
+    clientModule: clientComponents.MyRange as StencilReactComponent<MyRangeElement, MyRangeEvents, Components.MyRange>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyToggleEvents = NonNullable<unknown>;
 
-export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents, JSX.MyToggle> = /*@__PURE__*/ createComponent<MyToggleElement, MyToggleEvents, JSX.MyToggle>({
+export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents, Components.MyToggle> = /*@__PURE__*/ createComponent<MyToggleElement, MyToggleEvents, Components.MyToggle>({
     tagName: 'my-toggle',
     properties: {},
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyToggle as StencilReactComponent<MyToggleElement, MyToggleEvents, JSX.MyToggle>,
+    clientModule: clientComponents.MyToggle as StencilReactComponent<MyToggleElement, MyToggleEvents, Components.MyToggle>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyToggleContentEvents = NonNullable<unknown>;
 
-export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyToggleContentEvents, JSX.MyToggleContent> = /*@__PURE__*/ createComponent<MyToggleContentElement, MyToggleContentEvents, JSX.MyToggleContent>({
+export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyToggleContentEvents, Components.MyToggleContent> = /*@__PURE__*/ createComponent<MyToggleContentElement, MyToggleContentEvents, Components.MyToggleContent>({
     tagName: 'my-toggle-content',
     properties: { visible: 'visible' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyToggleContent as StencilReactComponent<MyToggleContentElement, MyToggleContentEvents, JSX.MyToggleContent>,
+    clientModule: clientComponents.MyToggleContent as StencilReactComponent<MyToggleContentElement, MyToggleContentEvents, Components.MyToggleContent>,
     serializeShadowRoot,
     getTagTransformer
 });
 
 export type MyTransformTestEvents = NonNullable<unknown>;
 
-export const MyTransformTest: StencilReactComponent<MyTransformTestElement, MyTransformTestEvents, JSX.MyTransformTest> = /*@__PURE__*/ createComponent<MyTransformTestElement, MyTransformTestEvents, JSX.MyTransformTest>({
+export const MyTransformTest: StencilReactComponent<MyTransformTestElement, MyTransformTestEvents, Components.MyTransformTest> = /*@__PURE__*/ createComponent<MyTransformTestElement, MyTransformTestEvents, Components.MyTransformTest>({
     tagName: 'my-transform-test',
     properties: { message: 'message' },
     hydrateModule: import('component-library/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyTransformTest as StencilReactComponent<MyTransformTestElement, MyTransformTestEvents, JSX.MyTransformTest>,
+    clientModule: clientComponents.MyTransformTest as StencilReactComponent<MyTransformTestElement, MyTransformTestEvents, Components.MyTransformTest>,
     serializeShadowRoot,
     getTagTransformer
 });

--- a/example-project/component-library-react/src/components.ts
+++ b/example-project/component-library-react/src/components.ts
@@ -13,7 +13,7 @@ import React from 'react';
 import { transformTag } from './tag-transformer.js';
 
 import { type CheckboxChangeEventDetail, type CheckboxChangeNestedEventDetail, type IMyComponent, type InputChangeEventDetail, type MyButtonCustomEvent, type MyButtonScopedCustomEvent, type MyCheckboxCustomEvent, type MyComponentScopedCustomEvent, type MyCounterCustomEvent, type MyInputCustomEvent, type MyInputScopedCustomEvent, type MyPopoverCustomEvent, type MyRadioCustomEvent, type MyRadioGroupCustomEvent, type MyRangeCustomEvent, type OverlayEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail } from "component-library";
-import type { JSX } from "component-library/components";
+import type { Components } from "component-library/components";
 import { MyButtonScoped as MyButtonScopedElement, defineCustomElement as defineMyButtonScoped } from "component-library/components/my-button-scoped.js";
 import { MyButton as MyButtonElement, defineCustomElement as defineMyButton } from "component-library/components/my-button.js";
 import { MyCheckbox as MyCheckboxElement, defineCustomElement as defineMyCheckbox } from "component-library/components/my-checkbox.js";
@@ -42,7 +42,7 @@ export type MyButtonEvents = {
     onMyBlur: EventName<MyButtonCustomEvent<void>>
 };
 
-export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents, JSX.MyButton> = /*@__PURE__*/ createComponent<MyButtonElement, MyButtonEvents, JSX.MyButton>({
+export const MyButton: StencilReactComponent<MyButtonElement, MyButtonEvents, Components.MyButton> = /*@__PURE__*/ createComponent<MyButtonElement, MyButtonEvents, Components.MyButton>({
     tagName: 'my-button',
     elementClass: MyButtonElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -60,7 +60,7 @@ export type MyButtonScopedEvents = {
     onMyBlur: EventName<MyButtonScopedCustomEvent<void>>
 };
 
-export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButtonScopedEvents, JSX.MyButtonScoped> = /*@__PURE__*/ createComponent<MyButtonScopedElement, MyButtonScopedEvents, JSX.MyButtonScoped>({
+export const MyButtonScoped: StencilReactComponent<MyButtonScopedElement, MyButtonScopedEvents, Components.MyButtonScoped> = /*@__PURE__*/ createComponent<MyButtonScopedElement, MyButtonScopedEvents, Components.MyButtonScoped>({
     tagName: 'my-button-scoped',
     elementClass: MyButtonScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -80,7 +80,7 @@ export type MyCheckboxEvents = {
     onIonBlur: EventName<MyCheckboxCustomEvent<void>>
 };
 
-export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEvents, JSX.MyCheckbox> = /*@__PURE__*/ createComponent<MyCheckboxElement, MyCheckboxEvents, JSX.MyCheckbox>({
+export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEvents, Components.MyCheckbox> = /*@__PURE__*/ createComponent<MyCheckboxElement, MyCheckboxEvents, Components.MyCheckbox>({
     tagName: 'my-checkbox',
     elementClass: MyCheckboxElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -97,7 +97,7 @@ export const MyCheckbox: StencilReactComponent<MyCheckboxElement, MyCheckboxEven
 
 export type MyComplexPropsEvents = NonNullable<unknown>;
 
-export const MyComplexProps: StencilReactComponent<MyComplexPropsElement, MyComplexPropsEvents, JSX.MyComplexProps> = /*@__PURE__*/ createComponent<MyComplexPropsElement, MyComplexPropsEvents, JSX.MyComplexProps>({
+export const MyComplexProps: StencilReactComponent<MyComplexPropsElement, MyComplexPropsEvents, Components.MyComplexProps> = /*@__PURE__*/ createComponent<MyComplexPropsElement, MyComplexPropsEvents, Components.MyComplexProps>({
     tagName: 'my-complex-props',
     elementClass: MyComplexPropsElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -109,7 +109,7 @@ export const MyComplexProps: StencilReactComponent<MyComplexPropsElement, MyComp
 
 export type MyComplexPropsScopedEvents = NonNullable<unknown>;
 
-export const MyComplexPropsScoped: StencilReactComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, JSX.MyComplexPropsScoped> = /*@__PURE__*/ createComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, JSX.MyComplexPropsScoped>({
+export const MyComplexPropsScoped: StencilReactComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, Components.MyComplexPropsScoped> = /*@__PURE__*/ createComponent<MyComplexPropsScopedElement, MyComplexPropsScopedEvents, Components.MyComplexPropsScoped>({
     tagName: 'my-complex-props-scoped',
     elementClass: MyComplexPropsScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -121,7 +121,7 @@ export const MyComplexPropsScoped: StencilReactComponent<MyComplexPropsScopedEle
 
 export type MyComponentEvents = NonNullable<unknown>;
 
-export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>({
+export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>({
     tagName: 'my-component',
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -133,7 +133,7 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
 
 export type MyComponentDelegatesFocusEvents = NonNullable<unknown>;
 
-export const MyComponentDelegatesFocus: StencilReactComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, JSX.MyComponentDelegatesFocus> = /*@__PURE__*/ createComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, JSX.MyComponentDelegatesFocus>({
+export const MyComponentDelegatesFocus: StencilReactComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, Components.MyComponentDelegatesFocus> = /*@__PURE__*/ createComponent<MyComponentDelegatesFocusElement, MyComponentDelegatesFocusEvents, Components.MyComponentDelegatesFocus>({
     tagName: 'my-component-delegates-focus',
     elementClass: MyComponentDelegatesFocusElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -145,7 +145,7 @@ export const MyComponentDelegatesFocus: StencilReactComponent<MyComponentDelegat
 
 export type MyComponentScopedEvents = { onMyCustomEvent: EventName<MyComponentScopedCustomEvent<IMyComponent.someVar>> };
 
-export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, MyComponentScopedEvents, JSX.MyComponentScoped> = /*@__PURE__*/ createComponent<MyComponentScopedElement, MyComponentScopedEvents, JSX.MyComponentScoped>({
+export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, MyComponentScopedEvents, Components.MyComponentScoped> = /*@__PURE__*/ createComponent<MyComponentScopedElement, MyComponentScopedEvents, Components.MyComponentScoped>({
     tagName: 'my-component-scoped',
     elementClass: MyComponentScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -157,7 +157,7 @@ export const MyComponentScoped: StencilReactComponent<MyComponentScopedElement, 
 
 export type MyCounterEvents = { onCount: EventName<MyCounterCustomEvent<number>> };
 
-export const MyCounter: StencilReactComponent<MyCounterElement, MyCounterEvents, JSX.MyCounter> = /*@__PURE__*/ createComponent<MyCounterElement, MyCounterEvents, JSX.MyCounter>({
+export const MyCounter: StencilReactComponent<MyCounterElement, MyCounterEvents, Components.MyCounter> = /*@__PURE__*/ createComponent<MyCounterElement, MyCounterEvents, Components.MyCounter>({
     tagName: 'my-counter',
     elementClass: MyCounterElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -174,7 +174,7 @@ export type MyInputEvents = {
     onMyFocus: EventName<MyInputCustomEvent<void>>
 };
 
-export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents, JSX.MyInput> = /*@__PURE__*/ createComponent<MyInputElement, MyInputEvents, JSX.MyInput>({
+export const MyInput: StencilReactComponent<MyInputElement, MyInputEvents, Components.MyInput> = /*@__PURE__*/ createComponent<MyInputElement, MyInputEvents, Components.MyInput>({
     tagName: 'my-input',
     elementClass: MyInputElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -196,7 +196,7 @@ export type MyInputScopedEvents = {
     onMyFocus: EventName<MyInputScopedCustomEvent<void>>
 };
 
-export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputScopedEvents, JSX.MyInputScoped> = /*@__PURE__*/ createComponent<MyInputScopedElement, MyInputScopedEvents, JSX.MyInputScoped>({
+export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputScopedEvents, Components.MyInputScoped> = /*@__PURE__*/ createComponent<MyInputScopedElement, MyInputScopedEvents, Components.MyInputScoped>({
     tagName: 'my-input-scoped',
     elementClass: MyInputScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -213,7 +213,7 @@ export const MyInputScoped: StencilReactComponent<MyInputScopedElement, MyInputS
 
 export type MyListEvents = NonNullable<unknown>;
 
-export const MyList: StencilReactComponent<MyListElement, MyListEvents, JSX.MyList> = /*@__PURE__*/ createComponent<MyListElement, MyListEvents, JSX.MyList>({
+export const MyList: StencilReactComponent<MyListElement, MyListEvents, Components.MyList> = /*@__PURE__*/ createComponent<MyListElement, MyListEvents, Components.MyList>({
     tagName: 'my-list',
     elementClass: MyListElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -225,7 +225,7 @@ export const MyList: StencilReactComponent<MyListElement, MyListEvents, JSX.MyLi
 
 export type MyListItemEvents = NonNullable<unknown>;
 
-export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEvents, JSX.MyListItem> = /*@__PURE__*/ createComponent<MyListItemElement, MyListItemEvents, JSX.MyListItem>({
+export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEvents, Components.MyListItem> = /*@__PURE__*/ createComponent<MyListItemElement, MyListItemEvents, Components.MyListItem>({
     tagName: 'my-list-item',
     elementClass: MyListItemElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -237,7 +237,7 @@ export const MyListItem: StencilReactComponent<MyListItemElement, MyListItemEven
 
 export type MyListItemScopedEvents = NonNullable<unknown>;
 
-export const MyListItemScoped: StencilReactComponent<MyListItemScopedElement, MyListItemScopedEvents, JSX.MyListItemScoped> = /*@__PURE__*/ createComponent<MyListItemScopedElement, MyListItemScopedEvents, JSX.MyListItemScoped>({
+export const MyListItemScoped: StencilReactComponent<MyListItemScopedElement, MyListItemScopedEvents, Components.MyListItemScoped> = /*@__PURE__*/ createComponent<MyListItemScopedElement, MyListItemScopedEvents, Components.MyListItemScoped>({
     tagName: 'my-list-item-scoped',
     elementClass: MyListItemScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -249,7 +249,7 @@ export const MyListItemScoped: StencilReactComponent<MyListItemScopedElement, My
 
 export type MyListScopedEvents = NonNullable<unknown>;
 
-export const MyListScoped: StencilReactComponent<MyListScopedElement, MyListScopedEvents, JSX.MyListScoped> = /*@__PURE__*/ createComponent<MyListScopedElement, MyListScopedEvents, JSX.MyListScoped>({
+export const MyListScoped: StencilReactComponent<MyListScopedElement, MyListScopedEvents, Components.MyListScoped> = /*@__PURE__*/ createComponent<MyListScopedElement, MyListScopedEvents, Components.MyListScoped>({
     tagName: 'my-list-scoped',
     elementClass: MyListScopedElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -266,7 +266,7 @@ export type MyPopoverEvents = {
     onMyPopoverDidDismiss: EventName<MyPopoverCustomEvent<OverlayEventDetail>>
 };
 
-export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents, JSX.MyPopover> = /*@__PURE__*/ createComponent<MyPopoverElement, MyPopoverEvents, JSX.MyPopover>({
+export const MyPopover: StencilReactComponent<MyPopoverElement, MyPopoverEvents, Components.MyPopover> = /*@__PURE__*/ createComponent<MyPopoverElement, MyPopoverEvents, Components.MyPopover>({
     tagName: 'my-popover',
     elementClass: MyPopoverElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -286,7 +286,7 @@ export type MyRadioEvents = {
     onIonBlur: EventName<MyRadioCustomEvent<void>>
 };
 
-export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents, JSX.MyRadio> = /*@__PURE__*/ createComponent<MyRadioElement, MyRadioEvents, JSX.MyRadio>({
+export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents, Components.MyRadio> = /*@__PURE__*/ createComponent<MyRadioElement, MyRadioEvents, Components.MyRadio>({
     tagName: 'my-radio',
     elementClass: MyRadioElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -301,7 +301,7 @@ export const MyRadio: StencilReactComponent<MyRadioElement, MyRadioEvents, JSX.M
 
 export type MyRadioGroupEvents = { onMyChange: EventName<MyRadioGroupCustomEvent<RadioGroupChangeEventDetail>> };
 
-export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGroupEvents, JSX.MyRadioGroup> = /*@__PURE__*/ createComponent<MyRadioGroupElement, MyRadioGroupEvents, JSX.MyRadioGroup>({
+export const MyRadioGroup: StencilReactComponent<MyRadioGroupElement, MyRadioGroupEvents, Components.MyRadioGroup> = /*@__PURE__*/ createComponent<MyRadioGroupElement, MyRadioGroupEvents, Components.MyRadioGroup>({
     tagName: 'my-radio-group',
     elementClass: MyRadioGroupElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -317,7 +317,7 @@ export type MyRangeEvents = {
     onMyBlur: EventName<MyRangeCustomEvent<void>>
 };
 
-export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents, JSX.MyRange> = /*@__PURE__*/ createComponent<MyRangeElement, MyRangeEvents, JSX.MyRange>({
+export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents, Components.MyRange> = /*@__PURE__*/ createComponent<MyRangeElement, MyRangeEvents, Components.MyRange>({
     tagName: 'my-range',
     elementClass: MyRangeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -333,7 +333,7 @@ export const MyRange: StencilReactComponent<MyRangeElement, MyRangeEvents, JSX.M
 
 export type MyToggleEvents = NonNullable<unknown>;
 
-export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents, JSX.MyToggle> = /*@__PURE__*/ createComponent<MyToggleElement, MyToggleEvents, JSX.MyToggle>({
+export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents, Components.MyToggle> = /*@__PURE__*/ createComponent<MyToggleElement, MyToggleEvents, Components.MyToggle>({
     tagName: 'my-toggle',
     elementClass: MyToggleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -345,7 +345,7 @@ export const MyToggle: StencilReactComponent<MyToggleElement, MyToggleEvents, JS
 
 export type MyToggleContentEvents = NonNullable<unknown>;
 
-export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyToggleContentEvents, JSX.MyToggleContent> = /*@__PURE__*/ createComponent<MyToggleContentElement, MyToggleContentEvents, JSX.MyToggleContent>({
+export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyToggleContentEvents, Components.MyToggleContent> = /*@__PURE__*/ createComponent<MyToggleContentElement, MyToggleContentEvents, Components.MyToggleContent>({
     tagName: 'my-toggle-content',
     elementClass: MyToggleContentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -357,7 +357,7 @@ export const MyToggleContent: StencilReactComponent<MyToggleContentElement, MyTo
 
 export type MyTransformTestEvents = NonNullable<unknown>;
 
-export const MyTransformTest: StencilReactComponent<MyTransformTestElement, MyTransformTestEvents, JSX.MyTransformTest> = /*@__PURE__*/ createComponent<MyTransformTestElement, MyTransformTestEvents, JSX.MyTransformTest>({
+export const MyTransformTest: StencilReactComponent<MyTransformTestElement, MyTransformTestEvents, Components.MyTransformTest> = /*@__PURE__*/ createComponent<MyTransformTestElement, MyTransformTestEvents, Components.MyTransformTest>({
     tagName: 'my-transform-test',
     elementClass: MyTransformTestElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.

--- a/example-project/component-library/src/components.d.ts
+++ b/example-project/component-library/src/components.d.ts
@@ -1344,7 +1344,7 @@ declare namespace LocalJSX {
         /**
           * The first name
          */
-        "first": string;
+        "first"?: string;
         /**
           * The last name
          */

--- a/example-project/component-library/src/components/my-component/my-component.tsx
+++ b/example-project/component-library/src/components/my-component/my-component.tsx
@@ -9,7 +9,7 @@ export class MyComponent {
   /**
    * The first name
    */
-  @Prop() first!: string;
+  @Prop() first: string;
 
   /**
    * The middle name (using kebab case name)

--- a/example-project/component-library/src/components/my-component/readme.md
+++ b/example-project/component-library/src/components/my-component/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property             | Attribute     | Description                             | Type     | Default     |
-| -------------------- | ------------- | --------------------------------------- | -------- | ----------- |
-| `first` _(required)_ | `first`       | The first name                          | `string` | `undefined` |
-| `last`               | `last`        | The last name                           | `string` | `undefined` |
-| `middleName`         | `middle-name` | The middle name (using kebab case name) | `string` | `undefined` |
+| Property     | Attribute     | Description                             | Type     | Default     |
+| ------------ | ------------- | --------------------------------------- | -------- | ----------- |
+| `first`      | `first`       | The first name                          | `string` | `undefined` |
+| `last`       | `last`        | The last name                           | `string` | `undefined` |
+| `middleName` | `middle-name` | The middle name (using kebab case name) | `string` | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/react/src/create-component-wrappers.test.ts
+++ b/packages/react/src/create-component-wrappers.test.ts
@@ -43,12 +43,12 @@ import type { StencilReactComponent } from '@stencil/react-output-target/runtime
 import { createComponent } from '@stencil/react-output-target/runtime';
 import React from 'react';
 
-import type { JSX } from "my-package/dist/custom-elements";
+import type { Components } from "my-package/dist/custom-elements";
 import { MyComponent as MyComponentElement, defineCustomElement as defineMyComponent } from "my-package/dist/custom-elements/my-component.js";
 
 export type MyComponentEvents = NonNullable<unknown>;
 
-export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>({
+export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>({
     tagName: 'my-component',
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -110,12 +110,12 @@ import type { StencilReactComponent } from '@stencil/react-output-target/runtime
 import { createComponent } from '@stencil/react-output-target/runtime';
 import React from 'react';
 
-import type { JSX } from "my-package/dist/custom-elements";
+import type { Components } from "my-package/dist/custom-elements";
 import { MyComponent as MyComponentElement, defineCustomElement as defineMyComponent } from "my-package/dist/custom-elements/my-component.js";
 
 export type MyComponentEvents = NonNullable<unknown>;
 
-export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>({
+export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>({
     tagName: 'my-component',
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -225,12 +225,12 @@ import { createComponent } from '@stencil/react-output-target/runtime';
 import React from 'react';
 
 import { type MyComponentCustomEvent } from "my-package";
-import type { JSX } from "my-package/dist/custom-elements";
+import type { Components } from "my-package/dist/custom-elements";
 import { MyComponent as MyComponentElement, defineCustomElement as defineMyComponent } from "my-package/dist/custom-elements/my-component.js";
 
 export type MyComponentEvents = { onMyEvent: EventName<MyComponentCustomEvent<IMyComponent.Events.Detail.MyComponentClicked>> };
 
-export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>({
+export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>({
     tagName: 'my-component',
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -280,11 +280,11 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
 
     const code = sourceFile.getFullText();
     expect(code)
-      .toContain(`export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>({
+      .toContain(`export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>({
     tagName: 'my-component',
     properties: { hasMaxLength: 'max-length' },
     hydrateModule: import('my-package/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyComponent as StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>,
+    clientModule: clientComponents.MyComponent as StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>,
     serializeShadowRoot
 });
 `);
@@ -347,7 +347,7 @@ export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentE
     const sourceFile = sourceFiles[1];
 
     const code = sourceFile.getFullText();
-    expect(code).not.toContain('createComponent<MyComponentAElement, MyComponentAEvents, JSX.MyComponentA>({');
-    expect(code).toContain('createComponent<MyComponentBElement, MyComponentBEvents, JSX.MyComponentB>({');
+    expect(code).not.toContain('createComponent<MyComponentAElement, MyComponentAEvents, Components.MyComponentA>({');
+    expect(code).toContain('createComponent<MyComponentBElement, MyComponentBEvents, Components.MyComponentB>({');
   });
 });

--- a/packages/react/src/create-stencil-react-components.test.ts
+++ b/packages/react/src/create-stencil-react-components.test.ts
@@ -32,7 +32,7 @@ describe('createStencilReactComponents', () => {
     );
     expect(result).toContain(`export type MyComponentEvents = NonNullable<unknown>;`);
     expect(result)
-      .toContain(`export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>({
+      .toContain(`export const MyComponent: StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent> = /*@__PURE__*/ createComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>({
     tagName: 'my-component',
     elementClass: MyComponentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -264,7 +264,7 @@ describe('createStencilReactComponents', () => {
     expect(result).toContain(`tagName: 'my-component',
     properties: { value: 'value' },
     hydrateModule: import('my-package/hydrate') as Promise<HydrateModule>,
-    clientModule: clientComponents.MyComponent as StencilReactComponent<MyComponentElement, MyComponentEvents, JSX.MyComponent>,
+    clientModule: clientComponents.MyComponent as StencilReactComponent<MyComponentElement, MyComponentEvents, Components.MyComponent>,
     serializeShadowRoot`);
   });
 

--- a/packages/react/src/create-stencil-react-components.ts
+++ b/packages/react/src/create-stencil-react-components.ts
@@ -57,7 +57,7 @@ import React from 'react';
 ${createComponentImport}
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
 ${transformTagImport}
-import type { JSX } from "${stencilPackageName}/${customElementsDir}";
+import type { Components } from "${stencilPackageName}/${customElementsDir}";
   `
   );
 
@@ -184,7 +184,7 @@ import type { JSX } from "${stencilPackageName}/${customElementsDir}";
     });
 
     const transformTagParam = transformTag ? ',\n    transformTag' : '';
-    const clientComponentCall = `/*@__PURE__*/ createComponent<${componentElement}, ${componentEventNamesType}, JSX.${reactTagName}>({
+    const clientComponentCall = `/*@__PURE__*/ createComponent<${componentElement}, ${componentEventNamesType}, Components.${reactTagName}>({
     tagName: '${tagName}',
     elementClass: ${componentElement},
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
@@ -194,7 +194,7 @@ import type { JSX } from "${stencilPackageName}/${customElementsDir}";
   })`;
 
     const getTagTransformerParam = transformTag ? ',\n    getTagTransformer' : '';
-    const serverComponentCall = `/*@__PURE__*/ createComponent<${componentElement}, ${componentEventNamesType}, JSX.${reactTagName}>({
+    const serverComponentCall = `/*@__PURE__*/ createComponent<${componentElement}, ${componentEventNamesType}, Components.${reactTagName}>({
     tagName: '${tagName}',
     properties: {${component.properties
       /**
@@ -205,7 +205,7 @@ import type { JSX } from "${stencilPackageName}/${customElementsDir}";
       .map((e) => `${e.name}: '${e.attribute}'`)
       .join(',\n')}},
     hydrateModule: import('${hydrateModule}') as Promise<HydrateModule>,
-    clientModule: clientComponents.${reactTagName} as StencilReactComponent<${componentElement}, ${componentEventNamesType}, JSX.${reactTagName}>,
+    clientModule: clientComponents.${reactTagName} as StencilReactComponent<${componentElement}, ${componentEventNamesType}, Components.${reactTagName}>,
     serializeShadowRoot${getTagTransformerParam}
   })`;
 
@@ -215,7 +215,7 @@ import type { JSX } from "${stencilPackageName}/${customElementsDir}";
       declarations: [
         {
           name: reactTagName,
-          type: `StencilReactComponent<${componentElement}, ${componentEventNamesType}, JSX.${reactTagName}>`,
+          type: `StencilReactComponent<${componentElement}, ${componentEventNamesType}, Components.${reactTagName}>`,
           initializer: hydrateModule ? serverComponentCall : clientComponentCall,
         },
       ],

--- a/packages/react/src/runtime/create-component.ts
+++ b/packages/react/src/runtime/create-component.ts
@@ -5,39 +5,40 @@ import { createComponent as createComponentWrapper } from '@lit/react';
 type EventNames = Record<string, EventName | string>;
 
 // Type that's compatible with both React 18 and 19
-type StencilProps<Element extends HTMLElement, Events extends EventNames, Props> = Omit<
-  React.HTMLAttributes<Element>,
-  keyof Events
+type StencilProps<I extends HTMLElement, E extends EventNames, C> = Omit<
+  React.HTMLAttributes<I>,
+  keyof E
 > &
-  Partial<{ [K in keyof Events]: Events[K] extends EventName<infer T> ? (event: T) => void : (event: any) => void }> &
-  Props &
-  React.RefAttributes<Element>;
+  Partial<{ [K in keyof E]: E[K] extends EventName<infer T> ? (event: T) => void : (event: any) => void }> &
+  Partial<C> &
+  React.RefAttributes<I>;
 
 export type StencilReactComponent<
-  Element extends HTMLElement,
-  Events extends EventNames = {},
-  Props = {},
-> = React.FunctionComponent<StencilProps<Element, Events, Props>>;
+  I extends HTMLElement,
+  E extends EventNames = {},
+  C = Omit<I, keyof HTMLElement>,
+> = React.FunctionComponent<StencilProps<I, E, C>>;
 
 /**
  * Defines a custom element and creates a React component.
  * @public
  */
-export const createComponent = <Element extends HTMLElement, Events extends EventNames = {}, Props = {}>({
+export const createComponent = <I extends HTMLElement, E extends EventNames = {}, C = Omit<I, keyof HTMLElement>>({
   defineCustomElement,
   tagName,
   transformTag,
   ...options
-}: Options<Element, Events> & {
+}: Options<I, E> & {
   defineCustomElement: () => void;
   transformTag?: (tagName: string) => string;
-}): StencilReactComponent<Element, Events, Props> => {
+}): StencilReactComponent<I, E, C> => {
   if (typeof defineCustomElement !== 'undefined') {
     defineCustomElement();
   }
   const finalTagName = transformTag ? transformTag(tagName) : tagName;
-  return createComponentWrapper<Element, Events>({
-    ...options,
-    tagName: finalTagName,
-  }) as unknown as StencilReactComponent<Element, Events, Props>;
+  return createComponentWrapper<I, E>({ ...options, tagName: finalTagName }) as unknown as StencilReactComponent<
+    I,
+    E,
+    C
+  >;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,21 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
 
+  example-project/component-library-angular/projects/library/dist:
+    dependencies:
+      '@angular/common':
+        specifier: ^20.0.0
+        version: 20.0.3(@angular/core@20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core':
+        specifier: ^20.0.0
+        version: 20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1)
+      component-library:
+        specifier: workspace:*
+        version: link:../../../../component-library
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
   example-project/component-library-react:
     dependencies:
       '@stencil/react-output-target':
@@ -240,6 +255,8 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.15.31)(jsdom@26.1.0)(less@4.3.0)(sass@1.89.2)(terser@5.42.0)
+
+  example-project/component-library/hydrate: {}
 
   example-project/next-15-runtime-based:
     dependencies:

--- a/tests/react/src/Input.tsx
+++ b/tests/react/src/Input.tsx
@@ -15,7 +15,7 @@ export function InputShadow() {
         /**
          * Test that we can use a property shared between MyInput and
          * HTMLElement that's absent from React.HTMLAttributes
-         */
+         */ 
         autofocus={true}
       />
       <div className="inputResult">


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally for affected output targets
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Reverts React 1.5.1. 
Due to the nature of the output target producing build-time artifacts *whilst also* being a runtime dependency, changing any type risks breaking the contract between the 2.

<!-- Please describe the current behavior that you are modifying. -->

<!-- Issues are required for both bug fixes and features. -->

Issue URL:

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
