### PR TITLE
fix(angular): emit explicit standalone value

### DIFF
--- a/example-project/component-library-angular/projects/library/src/directives/proxies.ts
+++ b/example-project/component-library-angular/projects/library/src/directives/proxies.ts
@@ -39,6 +39,7 @@ import { defineCustomElement as defineMyTransformTest } from 'component-library/
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'shape', 'size', 'strong', 'target', 'type'],
   outputs: ['myFocus', 'myBlur'],
+  standalone: true
 })
 export class MyButton {
   protected el: HTMLMyButtonElement;
@@ -74,6 +75,7 @@ export declare interface MyButton extends Components.MyButton {
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['buttonType', 'color', 'disabled', 'download', 'expand', 'fill', 'href', 'mode', 'rel', 'shape', 'size', 'strong', 'target', 'type'],
   outputs: ['myFocus', 'myBlur'],
+  standalone: true
 })
 export class MyButtonScoped {
   protected el: HTMLMyButtonScopedElement;
@@ -109,6 +111,7 @@ export declare interface MyButtonScoped extends Components.MyButtonScoped {
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['alignment', 'checked', 'color', 'disabled', 'indeterminate', 'justify', 'labelPlacement', 'mode', 'name', 'value'],
   outputs: ['ionChange', 'ionChangeNested', 'ionFocus', 'ionBlur'],
+  standalone: true
 })
 export class MyCheckbox {
   protected el: HTMLMyCheckboxElement;
@@ -159,6 +162,7 @@ For demonstration purposes to be able to test ways to handle more complex events
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['baz', 'foo', 'grault', 'quux', 'waldo'],
+  standalone: true
 })
 export class MyComplexProps {
   protected el: HTMLMyComplexPropsElement;
@@ -182,6 +186,7 @@ export declare interface MyComplexProps extends Components.MyComplexProps {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['baz', 'foo', 'grault', 'quux', 'waldo'],
+  standalone: true
 })
 export class MyComplexPropsScoped {
   protected el: HTMLMyComplexPropsScopedElement;
@@ -206,6 +211,7 @@ export declare interface MyComplexPropsScoped extends Components.MyComplexPropsS
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['first', 'kidsNames', 'last', 'middleName'],
   outputs: ['myCustomEvent'],
+  standalone: true
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;
@@ -232,6 +238,7 @@ export declare interface MyComponent extends Components.MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  standalone: true
 })
 export class MyComponentDelegatesFocus {
   protected el: HTMLMyComponentDelegatesFocusElement;
@@ -256,6 +263,7 @@ export declare interface MyComponentDelegatesFocus extends Components.MyComponen
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['first', 'last', 'middleName'],
   outputs: ['myCustomEvent'],
+  standalone: true
 })
 export class MyComponentScoped {
   protected el: HTMLMyComponentScopedElement;
@@ -288,6 +296,7 @@ export declare interface MyComponentScoped extends Components.MyComponentScoped 
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['startValue'],
   outputs: ['count'],
+  standalone: true
 })
 export class MyCounter {
   protected el: HTMLMyCounterElement;
@@ -319,6 +328,7 @@ export declare interface MyCounter extends Components.MyCounter {
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'],
   outputs: ['myInput', 'myChange', 'myBlur', 'myFocus'],
+  standalone: true
 })
 export class MyInput {
   protected el: HTMLMyInputElement;
@@ -367,6 +377,7 @@ export declare interface MyInput extends Components.MyInput {
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['accept', 'autocapitalize', 'autocomplete', 'autocorrect', 'autofocus', 'clearInput', 'clearOnEdit', 'color', 'disabled', 'enterkeyhint', 'inputmode', 'max', 'maxlength', 'min', 'minlength', 'mode', 'multiple', 'name', 'pattern', 'placeholder', 'readonly', 'required', 'size', 'spellcheck', 'step', 'type', 'value'],
   outputs: ['myInput', 'myChange', 'myBlur', 'myFocus'],
+  standalone: true
 })
 export class MyInputScoped {
   protected el: HTMLMyInputScopedElement;
@@ -412,6 +423,7 @@ export declare interface MyInputScoped extends Components.MyInputScoped {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  standalone: true
 })
 export class MyList {
   protected el: HTMLMyListElement;
@@ -434,6 +446,7 @@ export declare interface MyList extends Components.MyList {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  standalone: true
 })
 export class MyListItem {
   protected el: HTMLMyListItemElement;
@@ -456,6 +469,7 @@ export declare interface MyListItem extends Components.MyListItem {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  standalone: true
 })
 export class MyListItemScoped {
   protected el: HTMLMyListItemScopedElement;
@@ -478,6 +492,7 @@ export declare interface MyListItemScoped extends Components.MyListItemScoped {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  standalone: true
 })
 export class MyListScoped {
   protected el: HTMLMyListScopedElement;
@@ -503,6 +518,7 @@ export declare interface MyListScoped extends Components.MyListScoped {}
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['animated', 'backdropDismiss', { name: 'component', required: true }, 'componentProps', 'cssClass', 'event', 'keyboardClose', 'mode', 'showBackdrop', 'translucent'],
   outputs: ['myPopoverDidPresent', 'myPopoverWillPresent', 'myPopoverWillDismiss', 'myPopoverDidDismiss'],
+  standalone: true
 })
 export class MyPopover {
   protected el: HTMLMyPopoverElement;
@@ -550,6 +566,7 @@ export declare interface MyPopover extends Components.MyPopover {
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['alignment', 'color', 'disabled', 'justify', 'labelPlacement', 'mode', 'name', 'value'],
   outputs: ['ionFocus', 'ionBlur'],
+  standalone: true
 })
 export class MyRadio {
   protected el: HTMLMyRadioElement;
@@ -585,6 +602,7 @@ export declare interface MyRadio extends Components.MyRadio {
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['allowEmptySelection', 'compareWith', 'name', 'value'],
   outputs: ['myChange'],
+  standalone: true
 })
 export class MyRadioGroup {
   protected el: HTMLMyRadioGroupElement;
@@ -619,6 +637,7 @@ This event will not emit when programmatically setting the `value` property.
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['color', 'debounce', 'disabled', 'dualKnobs', 'max', 'min', 'mode', 'name', 'pin', 'snaps', 'step', 'ticks', 'value'],
   outputs: ['myChange', 'myFocus', 'myBlur'],
+  standalone: true
 })
 export class MyRange {
   protected el: HTMLMyRangeElement;
@@ -659,6 +678,7 @@ export declare interface MyRange extends Components.MyRange {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  standalone: true
 })
 export class MyToggle {
   protected el: HTMLMyToggleElement;
@@ -682,6 +702,7 @@ export declare interface MyToggle extends Components.MyToggle {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['visible'],
+  standalone: true
 })
 export class MyToggleContent {
   protected el: HTMLMyToggleContentElement;
@@ -705,6 +726,7 @@ export declare interface MyToggleContent extends Components.MyToggleContent {}
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: ['message'],
+  standalone: true
 })
 export class MyTransformTest {
   protected el: HTMLMyTransformTestElement;

--- a/packages/angular/src/generate-angular-component.ts
+++ b/packages/angular/src/generate-angular-component.ts
@@ -107,11 +107,7 @@ export const createAngularComponentDefinition = (
     proxyCmpOptions.push(`\n  methods: [${formattedMethods}]`);
   }
 
-  let standaloneOption = '';
-
-  if (!standalone) {
-    standaloneOption = `\n  standalone: false`;
-  }
+  const standaloneOption = `\n  standalone: ${standalone ? 'true' : 'false'}`;
 
   const propertyDeclarations = inlineComponentProps.map((m) =>
     createPropertyDeclaration(m, `Components.${tagNameAsPascal}['${m.name}']`, true)

--- a/packages/angular/tests/generate-angular-component.test.ts
+++ b/packages/angular/tests/generate-angular-component.test.ts
@@ -293,6 +293,7 @@ export class MyComponent {
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
   inputs: [],
+  standalone: true
 })
 export class MyComponent {
   protected el: HTMLMyComponentElement;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,21 +170,6 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
 
-  example-project/component-library-angular/projects/library/dist:
-    dependencies:
-      '@angular/common':
-        specifier: ^20.0.0
-        version: 20.0.3(@angular/core@20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
-      '@angular/core':
-        specifier: ^20.0.0
-        version: 20.0.3(@angular/compiler@20.0.3)(rxjs@7.8.2)(zone.js@0.15.1)
-      component-library:
-        specifier: workspace:*
-        version: link:../../../../component-library
-      tslib:
-        specifier: ^2.3.0
-        version: 2.8.1
-
   example-project/component-library-react:
     dependencies:
       '@stencil/react-output-target':
@@ -255,8 +240,6 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.15.31)(jsdom@26.1.0)(less@4.3.0)(sass@1.89.2)(terser@5.42.0)
-
-  example-project/component-library/hydrate: {}
 
   example-project/next-15-runtime-based:
     dependencies:


### PR DESCRIPTION
## Pull request checklist

<!-- Please note that this repository is largely maintained for the purposes of supporting the Ionic Framework -->
<!-- As a result, we may not immediately (or ever) get around to reviewing pull requests that do not support the Framework -->

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally for affected output targets
- [X] Tests (`npm test`) were run locally and passed
- [X] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

PR #653 made the lazy-component path emit explicit `standalone: false` to survive Angular 19+'s standalone-default flip, but left the standalone-component path emitting nothing and relying on Angular's default. That breaks downstream libraries that need to support multiple Angular versions with both standalone and lazy loaded components

## What is the new behavior?

Now we'll emit `standalone` explicitly on both sides so the generator output is correct regardless of which Angular version the consumer is on or what the default happens to be at that point in history.

Verified in a local spike branch of @ionic/angular which supports Angular 18-21 simultaneously via partial Ivy compilation.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
