### PR TITLE
fix(react): guard resolveType against exotic components and rendered SSR elements

### DIFF
--- a/example-project/next-15-runtime-based/src/app/named-slot/page.tsx
+++ b/example-project/next-15-runtime-based/src/app/named-slot/page.tsx
@@ -1,0 +1,64 @@
+/**
+ * Server-rendered page that exercises named slot serialization.
+ *
+ * Tests that Stencil SSR components passed into named slots of another Stencil SSR
+ * component are correctly serialized as light DOM children, so that the server-rendered
+ * HTML matches the client-hydrated DOM (no hydration mismatch).
+ *
+ * Covers both shadow (DSD) and scoped rendering modes.
+ */
+import { MyButton, MyButtonScoped, MyComponent, MyComponentScoped } from 'component-library-react/next';
+
+export default function NamedSlotPage() {
+  return (
+    <main style={{ display: 'flex', flexDirection: 'column', gap: '1rem', padding: '1rem' }}>
+      <h1>Named Slot SSR Tests</h1>
+
+      <section>
+        <h2>Shadow (DSD) — MyButton with named slot children</h2>
+
+        {/* Plain HTML element in a named slot */}
+        <MyButton>
+          <span slot="start">★</span>
+          Button with plain start slot
+        </MyButton>
+
+        {/* Stencil SSR component in the start named slot */}
+        <MyButton>
+          <MyComponent slot="start" first="Icon" last="Component">★</MyComponent>
+          Button with Stencil component in start slot
+        </MyButton>
+
+        {/* Stencil SSR component in the end named slot */}
+        <MyButton>
+          Button with Stencil component in end slot
+          <MyComponent slot="end" first="Icon" last="Component">→</MyComponent>
+        </MyButton>
+      </section>
+
+      <hr />
+
+      <section>
+        <h2>Scoped — MyButtonScoped with named slot children</h2>
+
+        {/* Plain HTML element in a named slot */}
+        <MyButtonScoped>
+          <span slot="start">★</span>
+          Scoped button with plain start slot
+        </MyButtonScoped>
+
+        {/* Stencil SSR scoped component in the start named slot */}
+        <MyButtonScoped>
+          <MyComponentScoped slot="start" first="Icon" last="Scoped">★</MyComponentScoped>
+          Scoped button with Stencil scoped component in start slot
+        </MyButtonScoped>
+
+        {/* Stencil SSR scoped component in the end named slot */}
+        <MyButtonScoped>
+          Scoped button with Stencil scoped component in end slot
+          <MyComponentScoped slot="end" first="Icon" last="Scoped">→</MyComponentScoped>
+        </MyButtonScoped>
+      </section>
+    </main>
+  );
+}

--- a/example-project/next-15-runtime-based/src/app/page.tsx
+++ b/example-project/next-15-runtime-based/src/app/page.tsx
@@ -39,6 +39,10 @@ export default function Home() {
         <MyRadio value="baz">Baz</MyRadio>
       </MyRadioGroup>
       <MyTransformTest message="Tag transformation test: should render as v1-my-transform-test" />
+      <hr />
+      <p>
+        <a href="/named-slot">Named Slot SSR Tests →</a>
+      </p>
     </>
   );
 }

--- a/packages/react/src/runtime/ssr.test.tsx
+++ b/packages/react/src/runtime/ssr.test.tsx
@@ -155,6 +155,80 @@ describe('SSR Boolean attributes & shadowrootdelegatesfocus', () => {
     expect(capturedRenderToStringArgs).toHaveLength(1);
   });
 
+  it('should serialize children that are React.forwardRef components without throwing', async () => {
+    // React.forwardRef components (e.g. those created by @lit/react) use hooks internally.
+    // resolveComponentTypes must NOT call their render() directly — that violates hook rules.
+    // They should be returned as-is for react-dom/server to handle natively.
+    const ForwardRefChild = React.forwardRef<HTMLElement, { slot?: string }>((_props, _ref) =>
+      React.createElement('my-counter', {})
+    );
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(Component({ children: React.createElement(ForwardRefChild, { slot: 'icon' }) })).resolves.toBeDefined();
+  });
+
+  it('should serialize children that are React.memo components without throwing', async () => {
+    // React.memo wraps a component in { $$typeof, type, compare }. The 'type' property
+    // would trigger the bottom recursive unwrap in resolveType, calling the inner function
+    // with hooks directly. The exotic guard must prevent this.
+    const MemoChild = React.memo((_props: { slot?: string }) =>
+      React.createElement('my-input', {})
+    );
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(Component({ children: React.createElement(MemoChild, { slot: 'icon' }) })).resolves.toBeDefined();
+  });
+
+  it('should serialize a nested Stencil SSR component as a slot child without throwing', async () => {
+    // When a Stencil SSR async component is used as a child (e.g. in a named slot),
+    // resolveComponentTypes must return the already-rendered element as-is, not try
+    // to use it as a `type` — which would cause renderToString to fail with
+    // "Objects are not valid as a React child".
+    const { renderToString } = await import('react-dom/server');
+    const realRenderToString = (await vi.importActual<typeof import('react-dom/server')>('react-dom/server')).renderToString;
+
+    // Parent component
+    const parentOptions: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const ParentComponent = createComponent(parentOptions);
+
+    // Child Stencil SSR component (async function)
+    const childOptions: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-component',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const ChildComponent = createComponent(childOptions);
+
+    // Use the real renderToString for children so the async issue would surface
+    vi.mocked(renderToString).mockImplementationOnce((element) => {
+      try {
+        return realRenderToString(element as React.ReactElement);
+      } catch {
+        // If the old (broken) code ran, it would produce "Objects are not valid as a React child"
+        // We re-throw so the test catches it
+        throw new Error('renderToString failed on nested Stencil SSR child');
+      }
+    });
+
+    await expect(
+      ParentComponent({
+        children: React.createElement(ChildComponent as any, { slot: 'start', first: 'Icon', last: 'Test' }),
+      })
+    ).resolves.toBeDefined();
+  });
+
   it('should handle mixed prop types correctly', async () => {
     const options: CreateComponentForSSROptions<HTMLElement> = {
       tagName: 'test-component',
@@ -184,4 +258,175 @@ describe('SSR Boolean attributes & shadowrootdelegatesfocus', () => {
     expect(htmlArg).toContain('maxLength="0"');
     expect(htmlArg).toContain('emptyString=""');
   });
+
+
+  it('should resolve React.lazy wrapping a React.forwardRef component without calling render directly', async () => {
+    const ForwardRefChild = React.forwardRef<HTMLElement, { slot?: string }>((_props, _ref) =>
+      React.createElement('my-counter', {})
+    );
+    const LazyForwardRef = React.lazy(() => Promise.resolve({ default: ForwardRefChild }));
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(
+      Component({ children: React.createElement(LazyForwardRef as any, { slot: 'icon' }) })
+    ).resolves.toBeDefined();
+  });
+
+  it('should resolve React.lazy wrapping a React.memo component without calling inner render directly', async () => {
+    const MemoChild = React.memo((_props: { slot?: string }) => React.createElement('my-input', {}));
+    const LazyMemo = React.lazy(() => Promise.resolve({ default: MemoChild }));
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(
+      Component({ children: React.createElement(LazyMemo as any, { slot: 'icon' }) })
+    ).resolves.toBeDefined();
+  });
+
+  it('should return React.memo wrapping a React.forwardRef component as-is without unwrapping', async () => {
+    const ForwardRefChild = React.forwardRef<HTMLElement, { slot?: string }>((_props, _ref) =>
+      React.createElement('my-counter', {})
+    );
+    const MemoForwardRef = React.memo(ForwardRefChild);
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(
+      Component({ children: React.createElement(MemoForwardRef as any, { slot: 'icon' }) })
+    ).resolves.toBeDefined();
+  });
+
+  it('should resolve deeply nested async Stencil SSR grandchild without error', async () => {
+    const grandchildOptions: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-counter',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const GrandchildComponent = createComponent(grandchildOptions);
+
+    const childOptions: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-component',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const ChildComponent = createComponent(childOptions);
+
+    const parentOptions: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const ParentComponent = createComponent(parentOptions);
+
+    await expect(
+      ParentComponent({
+        children: React.createElement(ChildComponent as any, { slot: 'start' },
+          React.createElement(GrandchildComponent as any, { slot: 'icon' })
+        ),
+      })
+    ).resolves.toBeDefined();
+  });
+
+  it('should pass through falsy children (null, undefined, false, 0) without throwing', async () => {
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-component',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(Component({ children: null })).resolves.toBeDefined();
+    await expect(Component({ children: undefined })).resolves.toBeDefined();
+    await expect(Component({ children: false as any })).resolves.toBeDefined();
+    await expect(Component({ children: 0 as any })).resolves.toBeDefined();
+  });
+
+  it('should resolve an array of mixed children (forwardRef, string, Stencil SSR, null) correctly', async () => {
+    const ForwardRefChild = React.forwardRef<HTMLElement, { slot?: string }>((_props, _ref) =>
+      React.createElement('my-counter', {})
+    );
+    const stencilOptions: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-component',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const StencilChild = createComponent(stencilOptions);
+
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(
+      Component({
+        children: [
+          React.createElement(ForwardRefChild, { slot: 'icon' }),
+          'plain text',
+          React.createElement(StencilChild as any, { slot: 'start' }),
+          null,
+        ] as any,
+      })
+    ).resolves.toBeDefined();
+  });
+
+  it('should render a class component slot child without crashing', async () => {
+    class ClassChild extends React.Component<{ slot?: string }> {
+      render() {
+        return React.createElement('span', {}, 'hello');
+      }
+    }
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(
+      Component({ children: React.createElement(ClassChild, { slot: 'label' }) })
+    ).resolves.toBeDefined();
+  });
+
+  it('should not throw when a function component slot child returns null', async () => {
+    const NullChild = (_props: { slot?: string }) => null;
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(
+      Component({ children: React.createElement(NullChild, { slot: 'icon' }) })
+    ).resolves.toBeDefined();
+  });
+
+  it('should not treat a plain object with a render key as a forwardRef exotic', async () => {
+    // isNativelyRenderedExotic must check $$typeof, not just the presence of 'render'.
+    // A plain object { render: fn } that is NOT a React exotic must not be short-circuited —
+    // it should fall through to normal resolution and be called as a function component.
+    const spy = vi.fn((_props: { slot?: string }) => React.createElement('span', {}, 'ok'));
+    const NotExotic = Object.assign(spy, {
+      render: () => React.createElement('span', {}, 'should not be called via render key'),
+    });
+    const options: CreateComponentForSSROptions<HTMLElement> = {
+      tagName: 'my-button',
+      properties: {},
+      hydrateModule: Promise.resolve(mockHydrateModule),
+    };
+    const Component = createComponent(options);
+    await expect(
+      Component({ children: React.createElement(NotExotic, { slot: 'icon' }) })
+    ).resolves.toBeDefined();
+    expect(spy).toHaveBeenCalled();
+  });
 });
+

--- a/packages/react/src/runtime/ssr.tsx
+++ b/packages/react/src/runtime/ssr.tsx
@@ -132,6 +132,25 @@ const isLazyExoticComponent = (value: unknown): value is LazyComponent<any, any>
   !!value && typeof value === 'object' && '_payload' in value;
 
 /**
+ * Returns true if the value is a React exotic component that react-dom/server handles
+ * natively (forwardRef or memo). These must NOT be called directly as their render
+ * functions use hooks, which are illegal outside of React's renderer.
+ *
+ * - React.forwardRef → { $$typeof: Symbol(react.forward_ref), render }
+ * - React.memo       → { $$typeof: Symbol(react.memo), type, compare }
+ *
+ * We require $$typeof to be present to avoid false-positives on plain objects
+ * that happen to have a 'render' or 'type' key.
+ */
+const isNativelyRenderedExotic = (
+  value: unknown
+): value is React.ForwardRefExoticComponent<any> | React.MemoExoticComponent<any> =>
+  !!value &&
+  typeof value === 'object' &&
+  '$$typeof' in value &&
+  ('render' in value || ('type' in value && 'compare' in value));
+
+/**
  * Transform a React component into a Stencil component for server side rendering. This logic is executed
  * by a React framework e.g. Next.js in an Node.js environment. The function will:
  *
@@ -405,13 +424,22 @@ async function resolveComponentTypes(children: ReactNode): Promise<ReactNode> {
 
       const { type, props } = child as React.ReactElement<object & { children: ReactNode }>;
 
+      const resolvedType = await resolveType(type, props as any);
+
+      // If resolveType returned a fully rendered React element (e.g. from an async Stencil SSR
+      // component), return it directly — it is already the final output and must not be wrapped
+      // back into a new element with itself as the `type`.
+      if (React.isValidElement(resolvedType)) {
+        return resolvedType;
+      }
+
       return {
         ...child,
         props: {
           ...props,
           children: await resolveComponentTypes(props.children),
         },
-        type: await resolveType(type, props as any),
+        type: resolvedType,
       } as ReactNode;
     })
   );
@@ -429,29 +457,40 @@ const resolveType = async (type: string | React.JSXElementConstructor<any>, prop
     const instance = new type(props, undefined);
     resolvedType = instance.render ? instance.render() : instance;
   } else if (isLazyExoticComponent(type)) {
-    // Handle React Lazy Component
+    // Handle React Lazy Component and Next.js RSC module references.
+    // React.lazy payload: { _status: -1, _result: promiseFn } → call _result() when uninitialized.
+    // Next.js RSC reference: { _result: undefined, _init: fn } → call _init(payload) to resolve.
     // https://github.com/facebook/react/blob/main/packages/react/src/ReactLazy.js
     const payload = type._payload;
-    const { default: lazyComponent } =
-      payload._status === -1 // Uninitialized = -1 so we need resolve the promise
-        ? await payload._result()
-        : payload._result;
+    let lazyComponent: any;
+    if (typeof (type as any)._init === 'function' && payload._result === undefined) {
+      // Next.js RSC module reference format: use _init to resolve the component
+      const resolved = await (type as any)._init(payload);
+      lazyComponent = resolved?.default ?? resolved;
+    } else {
+      const { default: def } =
+        payload._status === -1 // Uninitialized = -1 so we need resolve the promise
+          ? await payload._result()
+          : payload._result;
+      lazyComponent = def;
+    }
     // Now resolve the actual component type of the lazy component
     resolvedType = await resolveType(lazyComponent, props);
+  } else if (isNativelyRenderedExotic(type)) {
+    // React.forwardRef and React.memo objects are handled natively by react-dom/server.
+    // Calling their inner render/type functions directly violates React's hook rules.
+    // Return the exotic object as-is; renderToString will render it correctly.
+    return type;
   } else if (typeof type !== 'object') {
     // Child is a Function Component because React Server
     // Components can be a Promise we need to await it
     resolvedType = await type(props);
   }
 
-  // Recursively resolve the component type until we have a primitive element type
-  if (
-    !isEmpty(resolvedType) &&
-    !isPrimitive(resolvedType) &&
-    typeof resolvedType === 'object' &&
-    resolvedType !== null &&
-    'type' in resolvedType
-  ) {
+  // Recursively resolve the component type until we have a primitive element type.
+  // React.isValidElement narrows to ReactElement, giving `.type` as `string | JSXElementConstructor<any>`.
+  // Exotic components return early above, so a valid element here still needs its type resolved.
+  if (!isEmpty(resolvedType) && !isPrimitive(resolvedType) && React.isValidElement(resolvedType)) {
     resolvedType = await resolveType(resolvedType.type, props);
   }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally for affected output targets
- [x] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When a scoped SSR Stencil component has named-slot children that are `React.forwardRef` components, `React.memo` components, or other async Stencil SSR components, `resolveType` crashes or produces invalid output:

- `React.forwardRef` / `React.memo`: their render functions are called directly, violating React's hook rules.
- Async Stencil SSR child: the already-rendered `ReactElement` is spread back as the `type` of a new `createElement` call, throwing `"Objects are not valid as a React child"`.


## What is the new behavior?

- `React.forwardRef` and `React.memo` exotic components are detected and returned as-is for `react-dom/server` to handle natively.
- Already-rendered `ReactElement` values returned by async Stencil SSR components are returned directly without re-wrapping.
- Three new unit tests cover each case.
- A named-slot example page is added to the Next.js example project.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

These bugs only surface in the **scoped** SSR path. In DSD mode, named-slot children are plain light-DOM HTML so `resolveType` never encounters exotic component types. In scoped mode, `dangerouslySetInnerHTML` occupies the element itself, so slot content is passed as `children` — which `resolveComponentTypes` walks and calls `resolveType` on.