### PR TITLE
fix(angular): detect formatted transformer exports

### DIFF
--- a/example-project/component-library-angular/projects/library/scripts/patch-transform-selectors.mjs
+++ b/example-project/component-library-angular/projects/library/scripts/patch-transform-selectors.mjs
@@ -206,7 +206,7 @@ try {
 
     // Inject setTagTransformer call with the user's transformer
     // Find the export statement and add the call before it
-    const exportMatch = bundleContent.match(/export \{ setTagTransformer/);
+    const exportMatch = bundleContent.match(/export\s*\{[^}]*\bsetTagTransformer\b/);
     if (exportMatch && patchedCount > 0) {
       const transformerCode = `
 // Auto-injected by patch-transform-selectors

--- a/packages/angular/src/generate-transformtag-script.ts
+++ b/packages/angular/src/generate-transformtag-script.ts
@@ -215,7 +215,7 @@ try {
 
     // Inject setTagTransformer call with the user's transformer
     // Find the export statement and add the call before it
-    const exportMatch = bundleContent.match(/export \\{ setTagTransformer/);
+    const exportMatch = bundleContent.match(/export\\s*\\{[^}]*\\bsetTagTransformer\\b/);
     if (exportMatch && patchedCount > 0) {
       const transformerCode = \`
 // Auto-injected by patch-transform-selectors

--- a/packages/angular/tests/generate-transformtag-script.test.ts
+++ b/packages/angular/tests/generate-transformtag-script.test.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { CompilerCtx, ComponentCompilerMeta } from '@stencil/core/internal';
+import { afterEach, describe, expect, it } from 'vitest';
+import { generateTransformTagScript } from '../src/generate-transformtag-script';
+import type { OutputTargetAngular } from '../src/types';
+
+describe('generateTransformTagScript', () => {
+  let temporaryDirectory: string | undefined;
+
+  afterEach(async () => {
+    if (temporaryDirectory) {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+      temporaryDirectory = undefined;
+    }
+  });
+
+  it('injects the tag transformer when the export contains other symbols and newlines', async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), 'stencil-angular-transform-tag-'));
+
+    const libraryDirectory = join(temporaryDirectory, 'projects', 'library');
+    const bundleDirectory = join(libraryDirectory, 'fesm2022');
+    const bundlePath = join(bundleDirectory, 'library.mjs');
+    const directivesProxyFile = join(libraryDirectory, 'src', 'lib', 'proxies.ts');
+
+    await mkdir(bundleDirectory, { recursive: true });
+    await writeFile(
+      bundlePath,
+      `const MyComponent = { selector: 'my-component' };
+const myCustomMethod = () => {};
+const setTagTransformer = () => {};
+
+export {
+  myCustomMethod,
+  setTagTransformer
+};
+`
+    );
+
+    const compilerCtx = {
+      fs: {
+        writeFile: async (filePath: string, content: string) => {
+          await mkdir(dirname(filePath), { recursive: true });
+          await writeFile(filePath, content);
+        },
+      },
+    } as unknown as CompilerCtx;
+    const components = [{ tagName: 'my-component' }] as ComponentCompilerMeta[];
+    const outputTarget = {
+      componentCorePackage: '@example/stencil-lib',
+      directivesProxyFile,
+    } as OutputTargetAngular;
+
+    await generateTransformTagScript(compilerCtx, components, outputTarget, '@example/angular-lib');
+
+    const scriptPath = join(libraryDirectory, 'scripts', 'patch-transform-selectors.mjs');
+    execFileSync(process.execPath, [scriptPath, "(tag) => 'v1-' + tag"]);
+
+    const patchedBundle = await readFile(bundlePath, 'utf8');
+    expect(patchedBundle).toContain("selector: 'v1-my-component'");
+    expect(patchedBundle).toContain('stencilSetTagTransformer');
+  });
+});


### PR DESCRIPTION
## Pull request checklist

- [x] Tests for the change have been added
- [x] Docs have been reviewed; no documentation change is needed
- [x] The full monorepo build was run locally
- [x] Angular unit, integration, and browser tests were run locally
- [x] Prettier checks pass

## Pull request type

- [x] Bugfix

## What is the current behavior?

The generated Angular `transformTag` patcher only recognizes an export that starts exactly with `export { setTagTransformer`. When a bundler places another symbol first or formats the named export across lines, selectors are rewritten but the runtime transformer call is not injected.

Fixes #817.

## What is the new behavior?

- Detect `setTagTransformer` anywhere in a named export, with whitespace and newline-tolerant matching.
- Exercise the generated patcher behavior against a multiline export where another symbol appears first.
- Regenerate the checked-in Angular example patcher from the updated generator.

## Does this introduce a breaking change?

- [x] No

## Validation

- `pnpm run build`
- `pnpm --filter '@stencil/angular-output-target' --filter '*angular*' --filter 'ng-app' test`
- `pnpm run prettier.dry-run`
- `pnpm exec prettier --check packages/angular/src/generate-transformtag-script.ts packages/angular/tests/generate-transformtag-script.test.ts`
