### PR TITLE
fix(vue): remove conditional classes that are no longer bound

### DIFF
--- a/example-project/vue-app/src/components/ReactiveClassTest.vue
+++ b/example-project/vue-app/src/components/ReactiveClassTest.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { MyList, MyListItem } from 'component-library-vue'
+import { ref } from 'vue'
+
+const ids = ['a', 'b', 'c']
+const selected = ref('a')
+</script>
+
+<template>
+  <div class="reactive-class-test">
+    <h3>Reactive Class Removal Test (Issue #835)</h3>
+    <p>Selecting an item should leave exactly one item with the "is-active" class.</p>
+
+    <MyList>
+      <MyListItem
+        v-for="id in ids"
+        :key="id"
+        :data-testid="`reactive-item-${id}`"
+        :class="{ 'is-active': selected === id }"
+      >
+        item {{ id }}{{ selected === id ? ' (selected)' : '' }}
+      </MyListItem>
+    </MyList>
+
+    <div class="controls">
+      <button
+        v-for="id in ids"
+        :key="`select-${id}`"
+        :data-testid="`select-item-${id}-btn`"
+        @click="selected = id"
+      >
+        Select {{ id }}
+      </button>
+      <p data-testid="selected-item">
+        selected: <strong>{{ selected }}</strong>
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.reactive-class-test {
+  margin: 20px 0;
+  padding: 20px;
+  border: 2px solid #ccc;
+  border-radius: 8px;
+}
+
+.controls {
+  margin-top: 15px;
+}
+
+button {
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+:deep(.is-active) {
+  outline: 3px solid orange;
+}
+</style>

--- a/example-project/vue-app/src/views/BasicComposition.vue
+++ b/example-project/vue-app/src/views/BasicComposition.vue
@@ -37,6 +37,7 @@
     Check the DOM: the tag should be &lt;v1-my-transform-test&gt; instead of &lt;my-transform-test&gt;
   </p>
   <HydratedClassTest />
+  <ReactiveClassTest />
 </template>
 
 <script lang="ts">
@@ -47,6 +48,7 @@ import Input from '../components/Input.vue'
 // @ts-ignore
 import Checkbox from '../components/Checkbox.vue'
 import HydratedClassTest from '../components/HydratedClassTest.vue';
+import ReactiveClassTest from '../components/ReactiveClassTest.vue';
 import { MyComponent, MyCheckbox, MyInput, MyRadio, MyRadioGroup, MyTransformTest } from 'component-library-vue'
 
 
@@ -62,7 +64,8 @@ export default defineComponent({
     MyRadio,
     MyRadioGroup,
     MyTransformTest,
-    HydratedClassTest
+    HydratedClassTest,
+    ReactiveClassTest
   },
   setup() {
     const input = ref('')

--- a/example-project/vue-app/src/views/SfcTests.vue
+++ b/example-project/vue-app/src/views/SfcTests.vue
@@ -5,6 +5,7 @@ import Input from '../components/Input.vue'
 // @ts-ignore
 import Checkbox from '../components/Checkbox.vue';
 import HydratedClassTest from '../components/HydratedClassTest.vue';
+import ReactiveClassTest from '../components/ReactiveClassTest.vue';
 import { MyComponent, MyCheckbox, MyInput, MyRadio, MyRadioGroup, MyTransformTest } from 'component-library-vue'
 import { ref } from 'vue'
 
@@ -60,6 +61,7 @@ const radioGroupValue = ref('option1')
   </p>
   <hr />
   <HydratedClassTest />
+  <ReactiveClassTest />
 </template>
 
 <style scoped>

--- a/example-project/vue-app/tests/test.e2e.ts
+++ b/example-project/vue-app/tests/test.e2e.ts
@@ -127,6 +127,41 @@ describe('Stencil Vue Integration', () => {
         await expect(target).toHaveElementClass('hydrated');
         await expect(target).toHaveElementClass('static-class');
       });
+
+      it('should keep a conditional :class removed once the binding stops producing it', async () => {
+        await browser.url(scenario.path);
+
+        const items = ['a', 'b', 'c'];
+        const expectOnlyActive = async (activeId: string) => {
+          for (const id of items) {
+            const item = $(`[data-testid="reactive-item-${id}"]`);
+            if (id === activeId) {
+              await expect(item).toHaveElementClass('is-active');
+            } else {
+              await expect(item).not.toHaveElementClass('is-active');
+            }
+          }
+        };
+        const select = async (id: string) => {
+          await $(`[data-testid="select-item-${id}-btn"]`).click();
+          await expect($('[data-testid="selected-item"] strong')).toHaveText(id);
+        };
+
+        await expectOnlyActive('a');
+
+        await select('b');
+        await expectOnlyActive('b');
+
+        // Item 'a' is no longer selected but its class string is unchanged, so Vue skips patching it
+        await select('c');
+        await expectOnlyActive('c');
+
+        await select('a');
+        await expectOnlyActive('a');
+
+        // Stencil adds `hydrated`, so it has to survive the removals
+        await expect($('[data-testid="reactive-item-c"]')).toHaveElementClass('hydrated');
+      });
     })
   })
 });

--- a/packages/vue/src/runtime.test.ts
+++ b/packages/vue/src/runtime.test.ts
@@ -140,6 +140,202 @@ describe('defineContainer', () => {
     });
   });
 
+  describe('reactive class removal (issue #835)', () => {
+    // Passing children keeps the slots object unstable, so Vue re-renders the child on every
+    // parent update even when its props haven't changed
+    const mountList = (ids: string[]) => {
+      const MyComponent = defineContainer('my-component', undefined as any);
+      const WrapperComponent = defineComponent({
+        setup() {
+          const selected = ref(ids[0]);
+          return { selected };
+        },
+        render() {
+          return h(
+            'div',
+            ids.map((id) =>
+              h(
+                MyComponent,
+                { id: `item-${id}`, class: { 'is-active': this.selected === id } },
+                { default: () => `item ${id}` }
+              )
+            )
+          );
+        },
+      });
+
+      const wrapper = mount(WrapperComponent);
+      const elementFor = (id: string) => wrapper.element.querySelector(`#item-${id}`) as HTMLElement;
+      // Simulate Stencil adding its own class outside of Vue
+      ids.forEach((id) => elementFor(id).classList.add('hydrated'));
+
+      const activeIds = () => ids.filter((id) => elementFor(id).classList.contains('is-active'));
+      const select = async (id: string) => {
+        wrapper.vm.selected = id;
+        await wrapper.vm.$nextTick();
+      };
+
+      return { activeIds, select, elementFor };
+    };
+
+    it('should keep a conditional class removed on later re-renders', async () => {
+      const { activeIds, select } = mountList(['a', 'b', 'c']);
+
+      expect(activeIds()).toEqual(['a']);
+
+      await select('b');
+      expect(activeIds()).toEqual(['b']);
+
+      // Item 'a' is no longer bound but its class string is unchanged, so Vue skips patching it
+      await select('c');
+      expect(activeIds()).toEqual(['c']);
+
+      await select('a');
+      expect(activeIds()).toEqual(['a']);
+    });
+
+    it('should not drop runtime managed classes while removing a conditional class', async () => {
+      const { select, elementFor } = mountList(['a', 'b', 'c']);
+
+      await select('b');
+      await select('c');
+
+      expect(elementFor('a').classList.contains('hydrated')).toBe(true);
+      expect(elementFor('c').classList.contains('hydrated')).toBe(true);
+    });
+
+    it('should swap between two conditional classes', async () => {
+      const MyComponent = defineContainer('my-component', undefined as any);
+      const WrapperComponent = defineComponent({
+        setup() {
+          const isOn = ref(true);
+          return { isOn };
+        },
+        render() {
+          return h(MyComponent, { class: this.isOn ? 'on' : 'off' }, { default: () => 'content' });
+        },
+      });
+
+      const wrapper = mount(WrapperComponent);
+      const element = wrapper.find('my-component').element as HTMLElement;
+      element.classList.add('hydrated');
+
+      expect(element.classList.contains('on')).toBe(true);
+
+      wrapper.vm.isOn = false;
+      await wrapper.vm.$nextTick();
+      expect(element.classList.contains('on')).toBe(false);
+      expect(element.classList.contains('off')).toBe(true);
+
+      // A re-render that leaves the class binding untouched must not resurrect 'on'
+      wrapper.vm.$forceUpdate();
+      await wrapper.vm.$nextTick();
+      expect(element.classList.contains('on')).toBe(false);
+      expect(element.classList.contains('off')).toBe(true);
+      expect(element.classList.contains('hydrated')).toBe(true);
+    });
+
+    it('should not track an empty class binding as a class', async () => {
+      const MyComponent = defineContainer('my-component', undefined as any);
+      const WrapperComponent = defineComponent({
+        setup() {
+          const isActive = ref(false);
+          return { isActive };
+        },
+        render() {
+          return h(MyComponent, { class: { active: this.isActive } }, { default: () => 'content' });
+        },
+      });
+
+      const wrapper = mount(WrapperComponent);
+      const element = wrapper.find('my-component').element as HTMLElement;
+
+      expect(element.getAttribute('class')).toBe('');
+
+      wrapper.vm.isActive = true;
+      await wrapper.vm.$nextTick();
+      expect(element.classList.contains('active')).toBe(true);
+
+      wrapper.vm.isActive = false;
+      await wrapper.vm.$nextTick();
+      expect(element.classList.contains('active')).toBe(false);
+      expect(Array.from(element.classList)).toEqual([]);
+    });
+  });
+
+  describe('class attribute tokenization (issue ionic-framework#31393)', () => {
+    it('should tokenize a class attribute that spans several lines', async () => {
+      const MyComponent = defineContainer('my-component', undefined as any);
+      const wrapper = mount(MyComponent, {
+        attrs: {
+          class: '\n      first-class\n      second-class\n    ',
+        },
+      });
+
+      // The render that syncs the classes to the element only runs once the ref is set
+      await wrapper.vm.$nextTick();
+
+      expect(Array.from(wrapper.element.classList).sort()).toEqual(['first-class', 'second-class']);
+    });
+
+    it('should not tokenize on whitespace the DOM does not split on', async () => {
+      // A non-breaking space is whitespace to `\s` but not to `DOMTokenList`. Splitting on it would
+      // record `foo` and `bar`, neither of which matches the element's real token, so nothing
+      // would ever remove it
+      const MyComponent = defineContainer('my-component', undefined as any);
+      const WrapperComponent = defineComponent({
+        setup() {
+          const isActive = ref(true);
+          return { isActive };
+        },
+        render() {
+          return h(MyComponent, { class: this.isActive ? 'foo\u00a0bar' : '' }, { default: () => 'content' });
+        },
+      });
+
+      const wrapper = mount(WrapperComponent);
+      const element = wrapper.find('my-component').element as HTMLElement;
+      element.classList.add('hydrated');
+      await wrapper.vm.$nextTick();
+
+      expect(element.classList.contains('foo\u00a0bar')).toBe(true);
+      expect(element.classList.contains('foo')).toBe(false);
+
+      wrapper.vm.isActive = false;
+      await wrapper.vm.$nextTick();
+
+      expect(Array.from(element.classList)).toEqual(['hydrated']);
+    });
+
+    it('should remove a multi-line class once the binding stops producing it', async () => {
+      const MyComponent = defineContainer('my-component', undefined as any);
+      const WrapperComponent = defineComponent({
+        setup() {
+          const isActive = ref(true);
+          return { isActive };
+        },
+        render() {
+          return h(
+            MyComponent,
+            { class: this.isActive ? '\n  first-class\n  second-class\n' : '' },
+            { default: () => 'content' }
+          );
+        },
+      });
+
+      const wrapper = mount(WrapperComponent);
+      const element = wrapper.find('my-component').element as HTMLElement;
+      element.classList.add('hydrated');
+
+      wrapper.vm.isActive = false;
+      await wrapper.vm.$nextTick();
+
+      expect(element.classList.contains('first-class')).toBe(false);
+      expect(element.classList.contains('second-class')).toBe(false);
+      expect(element.classList.contains('hydrated')).toBe(true);
+    });
+  });
+
   describe('routerLink modifier key clicks (issue FW-7149)', () => {
     const mountWithRouter = (routerLink: string | undefined) => {
       const navigate = vi.fn();

--- a/packages/vue/src/runtime.ts
+++ b/packages/vue/src/runtime.ts
@@ -37,27 +37,61 @@ interface NavManager<T = any> {
   navigate: (options: T) => void;
 }
 
+/**
+ * Split a class attribute value into tokens the way `DOMTokenList` does, on runs of ASCII
+ * whitespace. A single-space split leaves whitespace inside the tokens of a multi-line class
+ * attribute, and `classList` rejects those. The token set has to match the DOM's exactly: one
+ * we record that the DOM never produced can never be removed again.
+ *
+ * React's `splitClassName` gets away with a looser `\s+` because it rewrites the whole `class`
+ * attribute, so its own tokens become the truth. We mutate individual tokens on an element the
+ * DOM already tokenized, so the two regexes are deliberately different.
+ */
 const getComponentClasses = (classes: unknown) => {
-  return (classes as string)?.split(' ') || [];
+  return ((classes as string)?.split(/[ \t\n\f\r]+/) || []).filter((className) => className.length > 0);
 };
 
+/**
+ * Sync the classes Vue supplied onto the host element, and return the ones it didn't supply
+ * (Stencil's `hydrated` and `sc-*` scope classes, plus anything added imperatively) so Vue's
+ * class patch doesn't wipe them. Vue merges that return value back with `attrs.class`.
+ *
+ * We read `previousVueClasses` for last render's Vue classes, then rewrite it with this
+ * render's.
+ *
+ * Classes Vue has stopped supplying have to come off the element before that return value is
+ * computed, or a stale one gets reported back as a class Vue never supplied and rewritten on
+ * every later render. Deleting the removal loop reintroduces issue #835.
+ */
 const syncElementClasses = (
   ref: Ref<HTMLElement | undefined>,
-  componentClasses: Set<string>,
+  previousVueClasses: Set<string>,
+  vueClasses: unknown,
   defaultClasses: string[] = []
 ) => {
+  const nextClasses = new Set(getComponentClasses(vueClasses));
+
   if (ref?.value) {
     const element = ref.value;
+    // drops the vue classes that are no longer bound
+    previousVueClasses.forEach((c) => {
+      if (!nextClasses.has(c)) {
+        element.classList.remove(c);
+      }
+    });
     // makes sure vue classes are on the actual element
-    componentClasses.forEach((c) => {
-      if (!!c && !element.classList.contains(c)) {
+    nextClasses.forEach((c) => {
+      if (!element.classList.contains(c)) {
         element.classList.add(c);
       }
     });
   }
 
+  previousVueClasses.clear();
+  nextClasses.forEach((c) => previousVueClasses.add(c));
+
   return [...Array.from(ref.value?.classList || []), ...defaultClasses].filter((c: string, i, self) => {
-    return !componentClasses.has(c) && self.indexOf(c) === i;
+    return !nextClasses.has(c) && self.indexOf(c) === i;
   });
 };
 
@@ -114,7 +148,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
     (props, { attrs, slots, emit }) => {
       let modelPropValue = modelProp ? props[modelProp as keyof InputProps<VModelType>] : undefined;
       const containerRef = ref<HTMLElement>();
-      const classes = new Set(getComponentClasses(attrs.class));
+      const previousVueClasses = new Set<string>();
 
       onMounted(() => {
         /**
@@ -210,10 +244,6 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
       return () => {
         modelPropValue = props[modelProp as keyof InputProps<VModelType>];
 
-        getComponentClasses(attrs.class).forEach((value) => {
-          classes.add(value);
-        });
-
         // @ts-expect-error
         const oldClick = props.onClick;
         const handleClick = (ev: Event) => {
@@ -227,7 +257,7 @@ export const defineContainer = <Props, VModelType = string | number | boolean>(
 
         const propsToAdd: Record<string, unknown> = {
           ref: containerRef,
-          class: syncElementClasses(containerRef, classes),
+          class: syncElementClasses(containerRef, previousVueClasses, attrs.class),
           onClick: handleClick,
         };
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`npm run build`) was run locally for affected output targets
- [X] Tests (`npm test`) were run locally and passed
- [X] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, `defineContainer` accumulates every class Vue supplies into a `Set` and never removes any, so `syncElementClasses` keeps re-adding classes the binding has dropped. Usually Vue's `patchClass` overwrites `className` wholesale and cleans up incidentally, but on a render where that string is unchanged Vue skips the patch and the re-added class sticks. A `v-for` of slot-bearing components hits it easily, since unstable slots re-render every item on each selection, including ones whose class binding didn't change.

Issue URL: resolves #835

## What is the new behavior?

The whole class cycle now lives in `syncElementClasses`: remove what Vue supplied last render and no longer supplies, add the current classes, record them for next time. Removal has to precede the return value, which is the element's classes minus the ones Vue supplied - a stale class left on would be reported back as runtime-managed and rewritten on every later render. This fixes ionic-team/ionic-framework#31392 in Ionic Framework. 

The tokenizer changed too, and the two aren't separable. Splitting on a single space leaves whitespace inside the tokens of a multi-line class attribute, which `classList` rejects (ionic-team/ionic-framework#31393). It now splits on runs of ASCII whitespace and drops empty tokens, which the removal loop needs since `classList.remove('')` throws.

The regex is `[ \t\n\f\r]+` rather than `\s+` because `\s` matches ten characters `DOMTokenList` doesn't split on. A value containing U+00A0 would record `foo` and `bar` when the element's only real token is `foo\u00a0bar`, so nothing could ever remove it. React's `splitClassName` can be looser because it rewrites the whole attribute; this runtime mutates individual tokens, so it has to match the DOM.

Seven unit tests cover both issues, plus an e2e test in `vue-app` with a `ReactiveClassTest.vue` fixture modelled on `HydratedClassTest.vue`.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The React target had the same bug, fixed in #827. The tokenizer now matches React's `splitClassName` and the reconcile computes the same result as `mergeClassNames`